### PR TITLE
feat: add start and end date options for days command 🧹

### DIFF
--- a/apps/cli/src/command/where-did-the-time-go.ts
+++ b/apps/cli/src/command/where-did-the-time-go.ts
@@ -1,8 +1,8 @@
 import {
   clampLineList,
+  formatDurationRough,
   mapPointListToLineList,
   startOfDayWithTimeZone,
-  formatDurationRough,
 } from '@stayradiated/pomo-core'
 import type { Line } from '@stayradiated/pomo-core'
 import {


### PR DESCRIPTION
This commit enhances the 'days' command by introducing the ability to specify start and end dates. This allows users to filter their data based on a specific time range, which improves the functionality and usability of the command.

- Modified `days.ts` to accept `startDate` and `endDate` as command options.
- Incorporated `chrono-node` for flexible date parsing based on user input.
- Implemented `startOfDayWithTimeZone` to ensure accurate date calculations.
- Updated the error handling to provide more informative messages if date parsing fails.
- Modified the logic in the `handler` function to retrieve point lists based on the specified date range.

Additionally, a small cleanup was made in the `where-did-the-time-go.ts` file by removing the duplicate import statement for `formatDurationRough`. 

These changes collectively enhance user experience and provide more flexibility in data querying.