### PR TITLE
feat(label): add label manager UI with emoji picker and mutators

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "tidy": "just fix"
   },
   "dependencies": {
+    "@emoji-mart/data": "1.2.1",
+    "@floating-ui/dom": "1.7.4",
     "@node-rs/argon2": "2.0.2",
     "@oslojs/crypto": "1.0.1",
     "@oslojs/encoding": "1.1.0",
@@ -19,6 +21,7 @@
     "cookie": "1.1.1",
     "date-fns": "4.1.0",
     "date-fns-tz": "3.2.0",
+    "emoji-mart": "5.6.0",
     "graphile-migrate": "1.4.1",
     "p-map": "7.0.4",
     "pg": "8.17.2",
@@ -26,6 +29,7 @@
     "replicache": "15.3.0",
     "resend": "6.8.0",
     "signia": "0.1.5",
+    "svelte-awesome-color-picker": "4.1.0",
     "websocket-ts": "2.2.1",
     "ws": "8.19.0",
     "zod": "4.3.5"
@@ -34,7 +38,7 @@
     "@biomejs/biome": "2.3.11",
     "@roughapp/replimock": "15.2.0",
     "@stayradiated/error-boundary": "4.3.0",
-    "@sveltejs/adapter-node": "5.5.1",
+    "@sveltejs/adapter-node": "5.5.0",
     "@sveltejs/kit": "2.50.0",
     "@sveltejs/vite-plugin-svelte": "6.2.4",
     "@types/node": "25.0.10",
@@ -49,12 +53,12 @@
     "knip": "5.82.1",
     "kysely": "0.28.10",
     "svelte": "5.48.0",
-    "svelte-check": "4.3.5",
+    "svelte-check": "4.3.4",
     "test-fixture-factory": "2.1.0",
     "type-fest": "5.4.1",
     "typescript": "5.9.3",
     "typescript-eslint": "8.53.1",
-    "vite": "7.3.1",
+    "vite": "7.3.0",
     "vitest": "4.0.17"
   },
   "knip": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@sveltejs/adapter-node": "5.5.1",
     "@sveltejs/kit": "2.50.0",
     "@sveltejs/vite-plugin-svelte": "6.2.4",
-    "@types/node": "25.0.9",
+    "@types/node": "25.0.10",
     "@types/pg": "8.16.0",
     "@types/ws": "8.18.1",
     "eslint": "9.39.2",
@@ -48,7 +48,7 @@
     "kanel-zod": "1.7.0",
     "knip": "5.82.1",
     "kysely": "0.28.10",
-    "svelte": "5.47.1",
+    "svelte": "5.48.0",
     "svelte-check": "4.3.5",
     "test-fixture-factory": "2.1.0",
     "type-fest": "5.4.1",
@@ -106,9 +106,6 @@
     "patchedDependencies": {
       "kanel-zod": "patches/kanel-zod.patch",
       "replicache": "patches/replicache.patch"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,12 @@ importers:
 
   .:
     dependencies:
+      '@emoji-mart/data':
+        specifier: 1.2.1
+        version: 1.2.1
+      '@floating-ui/dom':
+        specifier: 1.7.4
+        version: 1.7.4
       '@node-rs/argon2':
         specifier: 2.0.2
         version: 2.0.2
@@ -43,6 +49,9 @@ importers:
       date-fns-tz:
         specifier: 3.2.0
         version: 3.2.0(date-fns@4.1.0)
+      emoji-mart:
+        specifier: 5.6.0
+        version: 5.6.0
       graphile-migrate:
         specifier: 1.4.1
         version: 1.4.1
@@ -64,6 +73,9 @@ importers:
       signia:
         specifier: 0.1.5
         version: 0.1.5
+      svelte-awesome-color-picker:
+        specifier: 4.1.0
+        version: 4.1.0(svelte@5.48.0)
       websocket-ts:
         specifier: 2.2.1
         version: 2.2.1
@@ -84,14 +96,14 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       '@sveltejs/adapter-node':
-        specifier: 5.5.1
-        version: 5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))
+        specifier: 5.5.0
+        version: 5.5.0(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))
       '@sveltejs/kit':
         specifier: 2.50.0
-        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: 6.2.4
-        version: 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+        version: 6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
       '@types/node':
         specifier: 25.0.10
         version: 25.0.10
@@ -129,8 +141,8 @@ importers:
         specifier: 5.48.0
         version: 5.48.0
       svelte-check:
-        specifier: 4.3.5
-        version: 4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3)
+        specifier: 4.3.4
+        version: 4.3.4(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3)
       test-fixture-factory:
         specifier: 2.1.0
         version: 2.1.0
@@ -144,8 +156,8 @@ importers:
         specifier: 8.53.1
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
-        specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+        specifier: 7.3.0
+        version: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
       vitest:
         specifier: 4.0.17
         version: 4.0.17(@types/node@25.0.10)(jiti@2.6.1)
@@ -178,24 +190,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.11':
     resolution: {integrity: sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.11':
     resolution: {integrity: sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.11':
     resolution: {integrity: sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.11':
     resolution: {integrity: sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw==}
@@ -220,6 +236,9 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emoji-mart/data@1.2.1':
+    resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -415,6 +434,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@graphile/logger@0.2.0':
     resolution: {integrity: sha512-jjcWBokl9eb1gVJ85QmoaQ73CQ52xAaOCF29ukRbYNl6lY+ts0ErTaDYOBlejcbUs2OpaiqYLO5uDhyLFzWw4w==}
 
@@ -512,24 +540,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-arm64-musl@2.0.2':
     resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-linux-x64-gnu@2.0.2':
     resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-x64-musl@2.0.2':
     resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-wasm32-wasi@2.0.2':
     resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
@@ -624,41 +656,49 @@ packages:
     resolution: {integrity: sha512-0eVYZxSceNqGADzhlV4ZRqkHF0fjWxRXQOB7Qwl5y1gN/XYUDvMfip+ngtzj4dM7zQT4U97hUhJ7PUKSy/JIGQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.16.3':
     resolution: {integrity: sha512-B1BvLeZbgDdVN0FvU40l5Q7lej8310WlabCBaouk8jY7H7xbI8phtomTtk3Efmevgfy5hImaQJu6++OmcFb2NQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.16.3':
     resolution: {integrity: sha512-q7khglic3Jqak7uDgA3MFnjDeI7krQT595GDZpvFq785fmFYSx8rlTkoHzmhQtUisYtl4XG7WUscwsoidFUI4w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.16.3':
     resolution: {integrity: sha512-aFRNmQNPzDgQEbw2s3c8yJYRimacSDI+u9df8rn5nSKzTVitHmbEpZqfxpwNLCKIuLSNmozHR1z1OT+oZVeYqg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.16.3':
     resolution: {integrity: sha512-vZI85SvSMADcEL9G1TIrV0Rlkc1fY5Mup0DdlVC5EHPysZB4hXXHpr+h09pjlK5y+5om5foIzDRxE1baUCaWOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.16.3':
     resolution: {integrity: sha512-xiLBnaUlddFEzRHiHiSGEMbkg8EwZY6VD8F+3GfnFsiK3xg/4boaUV2bwXd+nUzl3UDQOMW1QcZJ4jJSb0qiJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.16.3':
     resolution: {integrity: sha512-6y0b05wIazJJgwu7yU/AYGFswzQQudYJBOb/otDhiDacp1+6ye8egoxx63iVo9lSpDbipL++54AJQFlcOHCB+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.16.3':
     resolution: {integrity: sha512-RmMgwuMa42c9logS7Pjprf5KCp8J1a1bFiuBFtG9/+yMu0BhY2t+0VR/um7pwtkNFvIQqAVh6gDOg/PnoKRcdQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.16.3':
     resolution: {integrity: sha512-/7AYRkjjW7xu1nrHgWUFy99Duj4/ydOBVaHtODie9/M6fFngo+8uQDFFnzmr4q//sd/cchIerISp/8CQ5TsqIA==}
@@ -739,128 +779,141 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.56.0':
-    resolution: {integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==}
+  '@rollup/rollup-android-arm-eabi@4.55.3':
+    resolution: {integrity: sha512-qyX8+93kK/7R5BEXPC2PjUt0+fS/VO2BVHjEHyIEWiYn88rcRBHmdLgoJjktBltgAf+NY7RfCGB1SoyKS/p9kg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.56.0':
-    resolution: {integrity: sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==}
+  '@rollup/rollup-android-arm64@4.55.3':
+    resolution: {integrity: sha512-6sHrL42bjt5dHQzJ12Q4vMKfN+kUnZ0atHHnv4V0Wd9JMTk7FDzSY35+7qbz3ypQYMBPANbpGK7JpnWNnhGt8g==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.56.0':
-    resolution: {integrity: sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==}
+  '@rollup/rollup-darwin-arm64@4.55.3':
+    resolution: {integrity: sha512-1ht2SpGIjEl2igJ9AbNpPIKzb1B5goXOcmtD0RFxnwNuMxqkR6AUaaErZz+4o+FKmzxcSNBOLrzsICZVNYa1Rw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.56.0':
-    resolution: {integrity: sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==}
+  '@rollup/rollup-darwin-x64@4.55.3':
+    resolution: {integrity: sha512-FYZ4iVunXxtT+CZqQoPVwPhH7549e/Gy7PIRRtq4t5f/vt54pX6eG9ebttRH6QSH7r/zxAFA4EZGlQ0h0FvXiA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.56.0':
-    resolution: {integrity: sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==}
+  '@rollup/rollup-freebsd-arm64@4.55.3':
+    resolution: {integrity: sha512-M/mwDCJ4wLsIgyxv2Lj7Len+UMHd4zAXu4GQ2UaCdksStglWhP61U3uowkaYBQBhVoNpwx5Hputo8eSqM7K82Q==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.56.0':
-    resolution: {integrity: sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==}
+  '@rollup/rollup-freebsd-x64@4.55.3':
+    resolution: {integrity: sha512-5jZT2c7jBCrMegKYTYTpni8mg8y3uY8gzeq2ndFOANwNuC/xJbVAoGKR9LhMDA0H3nIhvaqUoBEuJoICBudFrA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
-    resolution: {integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
+    resolution: {integrity: sha512-YeGUhkN1oA+iSPzzhEjVPS29YbViOr8s4lSsFaZKLHswgqP911xx25fPOyE9+khmN6W4VeM0aevbDp4kkEoHiA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.56.0':
-    resolution: {integrity: sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
+    resolution: {integrity: sha512-eo0iOIOvcAlWB3Z3eh8pVM8hZ0oVkK3AjEM9nSrkSug2l15qHzF3TOwT0747omI6+CJJvl7drwZepT+re6Fy/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.56.0':
-    resolution: {integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.55.3':
+    resolution: {integrity: sha512-DJay3ep76bKUDImmn//W5SvpjRN5LmK/ntWyeJs/dcnwiiHESd3N4uteK9FDLf0S0W8E6Y0sVRXpOCoQclQqNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.56.0':
-    resolution: {integrity: sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==}
+  '@rollup/rollup-linux-arm64-musl@4.55.3':
+    resolution: {integrity: sha512-BKKWQkY2WgJ5MC/ayvIJTHjy0JUGb5efaHCUiG/39sSUvAYRBaO3+/EK0AZT1RF3pSj86O24GLLik9mAYu0IJg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.56.0':
-    resolution: {integrity: sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==}
+  '@rollup/rollup-linux-loong64-gnu@4.55.3':
+    resolution: {integrity: sha512-Q9nVlWtKAG7ISW80OiZGxTr6rYtyDSkauHUtvkQI6TNOJjFvpj4gcH+KaJihqYInnAzEEUetPQubRwHef4exVg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.56.0':
-    resolution: {integrity: sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==}
+  '@rollup/rollup-linux-loong64-musl@4.55.3':
+    resolution: {integrity: sha512-2H5LmhzrpC4fFRNwknzmmTvvyJPHwESoJgyReXeFoYYuIDfBhP29TEXOkCJE/KxHi27mj7wDUClNq78ue3QEBQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.56.0':
-    resolution: {integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
+    resolution: {integrity: sha512-9S542V0ie9LCTznPYlvaeySwBeIEa7rDBgLHKZ5S9DBgcqdJYburabm8TqiqG6mrdTzfV5uttQRHcbKff9lWtA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.56.0':
-    resolution: {integrity: sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==}
+  '@rollup/rollup-linux-ppc64-musl@4.55.3':
+    resolution: {integrity: sha512-ukxw+YH3XXpcezLgbJeasgxyTbdpnNAkrIlFGDl7t+pgCxZ89/6n1a+MxlY7CegU+nDgrgdqDelPRNQ/47zs0g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.56.0':
-    resolution: {integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==}
+  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
+    resolution: {integrity: sha512-Iauw9UsTTvlF++FhghFJjqYxyXdggXsOqGpFBylaRopVpcbfyIIsNvkf9oGwfgIcf57z3m8+/oSYTo6HutBFNw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.56.0':
-    resolution: {integrity: sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.55.3':
+    resolution: {integrity: sha512-3OqKAHSEQXKdq9mQ4eajqUgNIK27VZPW3I26EP8miIzuKzCJ3aW3oEn2pzF+4/Hj/Moc0YDsOtBgT5bZ56/vcA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.56.0':
-    resolution: {integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.55.3':
+    resolution: {integrity: sha512-0CM8dSVzVIaqMcXIFej8zZrSFLnGrAE8qlNbbHfTw1EEPnFTg1U1ekI0JdzjPyzSfUsHWtodilQQG/RA55berA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.56.0':
-    resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
+  '@rollup/rollup-linux-x64-gnu@4.55.3':
+    resolution: {integrity: sha512-+fgJE12FZMIgBaKIAGd45rxf+5ftcycANJRWk8Vz0NnMTM5rADPGuRFTYar+Mqs560xuART7XsX2lSACa1iOmQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.56.0':
-    resolution: {integrity: sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==}
+  '@rollup/rollup-linux-x64-musl@4.55.3':
+    resolution: {integrity: sha512-tMD7NnbAolWPzQlJQJjVFh/fNH3K/KnA7K8gv2dJWCwwnaK6DFCYST1QXYWfu5V0cDwarWC8Sf/cfMHniNq21A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.56.0':
-    resolution: {integrity: sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==}
+  '@rollup/rollup-openbsd-x64@4.55.3':
+    resolution: {integrity: sha512-u5KsqxOxjEeIbn7bUK1MPM34jrnPwjeqgyin4/N6e/KzXKfpE9Mi0nCxcQjaM9lLmPcHmn/xx1yOjgTMtu1jWQ==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.56.0':
-    resolution: {integrity: sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==}
+  '@rollup/rollup-openharmony-arm64@4.55.3':
+    resolution: {integrity: sha512-vo54aXwjpTtsAnb3ca7Yxs9t2INZg7QdXN/7yaoG7nPGbOBXYXQY41Km+S1Ov26vzOAzLcAjmMdjyEqS1JkVhw==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.56.0':
-    resolution: {integrity: sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==}
+  '@rollup/rollup-win32-arm64-msvc@4.55.3':
+    resolution: {integrity: sha512-HI+PIVZ+m+9AgpnY3pt6rinUdRYrGHvmVdsNQ4odNqQ/eRF78DVpMR7mOq7nW06QxpczibwBmeQzB68wJ+4W4A==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.56.0':
-    resolution: {integrity: sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==}
+  '@rollup/rollup-win32-ia32-msvc@4.55.3':
+    resolution: {integrity: sha512-vRByotbdMo3Wdi+8oC2nVxtc3RkkFKrGaok+a62AT8lz/YBuQjaVYAS5Zcs3tPzW43Vsf9J0wehJbUY5xRSekA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.56.0':
-    resolution: {integrity: sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==}
+  '@rollup/rollup-win32-x64-gnu@4.55.3':
+    resolution: {integrity: sha512-POZHq7UeuzMJljC5NjKi8vKMFN6/5EOqcX1yGntNLp7rUTpBAXQ1hW8kWPFxYLv07QMcNM75xqVLGPWQq6TKFA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.56.0':
-    resolution: {integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==}
+  '@rollup/rollup-win32-x64-msvc@4.55.3':
+    resolution: {integrity: sha512-aPFONczE4fUFKNXszdvnd2GqKEYQdV5oEsIbKPujJmWlCI9zEsv1Otig8RKK+X9bed9gFUN6LAeN4ZcNuu4zjg==}
     cpu: [x64]
     os: [win32]
 
@@ -893,8 +946,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/adapter-node@5.5.1':
-    resolution: {integrity: sha512-VpZdPNRPQuZRtgfAMETPWWKpZx9JwXmUUsgz/+eSpw/Oh7+2O1uZHlsQTuyfxydJHPrRzjfu/ItcJjY4oscCiQ==}
+  '@sveltejs/adapter-node@5.5.0':
+    resolution: {integrity: sha512-xHzWyo2vRYqR/DyyFboIOVplz411RAyZvt0/UVPebRIhg3PGXty09mjiRt0nPj7zL0oPxqeCTu4RmHdsFkP/7w==}
     peerDependencies:
       '@sveltejs/kit': ^2.4.0
 
@@ -1176,6 +1229,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
 
@@ -1277,6 +1333,9 @@ packages:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
     engines: {node: '>=14'}
     hasBin: true
+
+  emoji-mart@5.6.0:
+    resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2050,8 +2109,8 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rollup@4.56.0:
-    resolution: {integrity: sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==}
+  rollup@4.55.3:
+    resolution: {integrity: sha512-y9yUpfQvetAjiDLtNMf1hL9NXchIJgWt6zIKeoB+tCd3npX08Eqfzg60V9DhIGVMtQ0AlMkFw5xa+AQ37zxnAA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2155,8 +2214,18 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte-check@4.3.5:
-    resolution: {integrity: sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q==}
+  svelte-awesome-color-picker@4.1.0:
+    resolution: {integrity: sha512-afiSB3eTBlqu96f4+rjBvqG3eCaLwuneNYHe587Wr4Ien6yQWeztGZunPT0FmiI7wFFBVNUlJQLYutII8LfQUg==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  svelte-awesome-slider@2.0.0:
+    resolution: {integrity: sha512-YBkOdYm1Feaqsn2JkJBRs+Kc/X3Qy/3GuVmI7GmoYDjBaHkjx9uH4khTuED22z57Hg3gGWeDhp/clIjWDdLNaw==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  svelte-check@4.3.4:
+    resolution: {integrity: sha512-DVWvxhBrDsd+0hHWKfjP99lsSXASeOhHJYyuKOFYJcP7ThfSCKgjVarE8XfuMWpS5JV3AlDf+iK1YGGo2TACdw==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
@@ -2338,8 +2407,8 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.0:
+    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2554,6 +2623,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emoji-mart/data@1.2.1': {}
+
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
@@ -2677,6 +2748,17 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/utils@0.2.10': {}
 
   '@graphile/logger@0.2.0': {}
 
@@ -2906,9 +2988,9 @@ snapshots:
 
   '@rocicorp/resolver@1.0.2': {}
 
-  '@rollup/plugin-commonjs@28.0.9(rollup@4.56.0)':
+  '@rollup/plugin-commonjs@28.0.9(rollup@4.55.3)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2916,105 +2998,105 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.56.0
+      rollup: 4.55.3
 
-  '@rollup/plugin-json@6.1.0(rollup@4.56.0)':
+  '@rollup/plugin-json@6.1.0(rollup@4.55.3)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
     optionalDependencies:
-      rollup: 4.56.0
+      rollup: 4.55.3
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.56.0)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.55.3)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
     optionalDependencies:
-      rollup: 4.56.0
+      rollup: 4.55.3
 
-  '@rollup/pluginutils@5.3.0(rollup@4.56.0)':
+  '@rollup/pluginutils@5.3.0(rollup@4.55.3)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.56.0
+      rollup: 4.55.3
 
-  '@rollup/rollup-android-arm-eabi@4.56.0':
+  '@rollup/rollup-android-arm-eabi@4.55.3':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.56.0':
+  '@rollup/rollup-android-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.56.0':
+  '@rollup/rollup-darwin-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.56.0':
+  '@rollup/rollup-darwin-x64@4.55.3':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.56.0':
+  '@rollup/rollup-freebsd-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.56.0':
+  '@rollup/rollup-freebsd-x64@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.56.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.56.0':
+  '@rollup/rollup-linux-arm64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.56.0':
+  '@rollup/rollup-linux-arm64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.56.0':
+  '@rollup/rollup-linux-loong64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.56.0':
+  '@rollup/rollup-linux-loong64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.56.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.56.0':
+  '@rollup/rollup-linux-ppc64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.56.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.56.0':
+  '@rollup/rollup-linux-riscv64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.56.0':
+  '@rollup/rollup-linux-s390x-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.56.0':
+  '@rollup/rollup-linux-x64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.56.0':
+  '@rollup/rollup-linux-x64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.56.0':
+  '@rollup/rollup-openbsd-x64@4.55.3':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.56.0':
+  '@rollup/rollup-openharmony-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.56.0':
+  '@rollup/rollup-win32-arm64-msvc@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.56.0':
+  '@rollup/rollup-win32-ia32-msvc@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.56.0':
+  '@rollup/rollup-win32-x64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.56.0':
+  '@rollup/rollup-win32-x64-msvc@4.55.3':
     optional: true
 
   '@roughapp/replimock@15.2.0(@electric-sql/pglite@0.3.15)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)':
@@ -3064,19 +3146,19 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-node@5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))':
+  '@sveltejs/adapter-node@5.5.0(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))':
     dependencies:
-      '@rollup/plugin-commonjs': 28.0.9(rollup@4.56.0)
-      '@rollup/plugin-json': 6.1.0(rollup@4.56.0)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.56.0)
-      '@sveltejs/kit': 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
-      rollup: 4.56.0
+      '@rollup/plugin-commonjs': 28.0.9(rollup@4.55.3)
+      '@rollup/plugin-json': 6.1.0(rollup@4.55.3)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.55.3)
+      '@sveltejs/kit': 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
+      rollup: 4.55.3
 
-  '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
+  '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -3089,26 +3171,26 @@ snapshots:
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.48.0
-      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
       obug: 2.1.1
       svelte: 5.48.0
-      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.48.0
-      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
+      vitefu: 1.1.1(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
 
   '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.48.0)':
     dependencies:
@@ -3254,13 +3336,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
+  '@vitest/mocker@4.0.17(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.0.17':
     dependencies:
@@ -3393,6 +3475,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colord@2.9.3: {}
+
   colorette@2.0.19: {}
 
   commander@10.0.1: {}
@@ -3476,6 +3560,8 @@ snapshots:
       commander: 10.0.1
       minimatch: 9.0.1
       semver: 7.7.3
+
+  emoji-mart@5.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -4264,35 +4350,35 @@ snapshots:
       glob: 13.0.0
       package-json-from-dist: 1.0.1
 
-  rollup@4.56.0:
+  rollup@4.55.3:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.56.0
-      '@rollup/rollup-android-arm64': 4.56.0
-      '@rollup/rollup-darwin-arm64': 4.56.0
-      '@rollup/rollup-darwin-x64': 4.56.0
-      '@rollup/rollup-freebsd-arm64': 4.56.0
-      '@rollup/rollup-freebsd-x64': 4.56.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.56.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.56.0
-      '@rollup/rollup-linux-arm64-gnu': 4.56.0
-      '@rollup/rollup-linux-arm64-musl': 4.56.0
-      '@rollup/rollup-linux-loong64-gnu': 4.56.0
-      '@rollup/rollup-linux-loong64-musl': 4.56.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.56.0
-      '@rollup/rollup-linux-ppc64-musl': 4.56.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.56.0
-      '@rollup/rollup-linux-riscv64-musl': 4.56.0
-      '@rollup/rollup-linux-s390x-gnu': 4.56.0
-      '@rollup/rollup-linux-x64-gnu': 4.56.0
-      '@rollup/rollup-linux-x64-musl': 4.56.0
-      '@rollup/rollup-openbsd-x64': 4.56.0
-      '@rollup/rollup-openharmony-arm64': 4.56.0
-      '@rollup/rollup-win32-arm64-msvc': 4.56.0
-      '@rollup/rollup-win32-ia32-msvc': 4.56.0
-      '@rollup/rollup-win32-x64-gnu': 4.56.0
-      '@rollup/rollup-win32-x64-msvc': 4.56.0
+      '@rollup/rollup-android-arm-eabi': 4.55.3
+      '@rollup/rollup-android-arm64': 4.55.3
+      '@rollup/rollup-darwin-arm64': 4.55.3
+      '@rollup/rollup-darwin-x64': 4.55.3
+      '@rollup/rollup-freebsd-arm64': 4.55.3
+      '@rollup/rollup-freebsd-x64': 4.55.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.55.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.55.3
+      '@rollup/rollup-linux-arm64-gnu': 4.55.3
+      '@rollup/rollup-linux-arm64-musl': 4.55.3
+      '@rollup/rollup-linux-loong64-gnu': 4.55.3
+      '@rollup/rollup-linux-loong64-musl': 4.55.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.55.3
+      '@rollup/rollup-linux-ppc64-musl': 4.55.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.55.3
+      '@rollup/rollup-linux-riscv64-musl': 4.55.3
+      '@rollup/rollup-linux-s390x-gnu': 4.55.3
+      '@rollup/rollup-linux-x64-gnu': 4.55.3
+      '@rollup/rollup-linux-x64-musl': 4.55.3
+      '@rollup/rollup-openbsd-x64': 4.55.3
+      '@rollup/rollup-openharmony-arm64': 4.55.3
+      '@rollup/rollup-win32-arm64-msvc': 4.55.3
+      '@rollup/rollup-win32-ia32-msvc': 4.55.3
+      '@rollup/rollup-win32-x64-gnu': 4.55.3
+      '@rollup/rollup-win32-x64-msvc': 4.55.3
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -4380,7 +4466,17 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3):
+  svelte-awesome-color-picker@4.1.0(svelte@5.48.0):
+    dependencies:
+      colord: 2.9.3
+      svelte: 5.48.0
+      svelte-awesome-slider: 2.0.0(svelte@5.48.0)
+
+  svelte-awesome-slider@2.0.0(svelte@5.48.0):
+    dependencies:
+      svelte: 5.48.0
+
+  svelte-check@4.3.4(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
@@ -4499,27 +4595,27 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1):
+  vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.56.0
+      rollup: 4.55.3
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.0.10
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitefu@1.1.1(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)):
+  vitefu@1.1.1(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
 
   vitest@4.0.17(@types/node@25.0.10)(jiti@2.6.1):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      '@vitest/mocker': 4.0.17(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -4536,7 +4632,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 1.1.0(@stayradiated/error-boundary@4.3.0)(p-map@7.0.4)
       '@sveltelaunch/svelte-5-email':
         specifier: 0.0.11
-        version: 0.0.11(svelte@5.47.1)
+        version: 0.0.11(svelte@5.48.0)
       async-mutex:
         specifier: 0.5.0
         version: 0.5.0
@@ -85,16 +85,16 @@ importers:
         version: 4.3.0
       '@sveltejs/adapter-node':
         specifier: 5.5.1
-        version: 5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.47.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))
+        version: 5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))
       '@sveltejs/kit':
         specifier: 2.50.0
-        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.47.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: 6.2.4
-        version: 6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+        version: 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 25.0.10
+        version: 25.0.10
       '@types/pg':
         specifier: 8.16.0
         version: 8.16.0
@@ -106,7 +106,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-plugin-svelte:
         specifier: 3.14.0
-        version: 3.14.0(eslint@9.39.2(jiti@2.6.1))(svelte@5.47.1)
+        version: 3.14.0(eslint@9.39.2(jiti@2.6.1))(svelte@5.48.0)
       id128:
         specifier: 1.6.6
         version: 1.6.6
@@ -121,16 +121,16 @@ importers:
         version: 1.7.0(patch_hash=e741c9afd9437ef4707a8df454c4da263c4f96c2d4dd101c24f993647513f946)
       knip:
         specifier: 5.82.1
-        version: 5.82.1(@types/node@25.0.9)(typescript@5.9.3)
+        version: 5.82.1(@types/node@25.0.10)(typescript@5.9.3)
       kysely:
         specifier: 0.28.10
         version: 0.28.10
       svelte:
-        specifier: 5.47.1
-        version: 5.47.1
+        specifier: 5.48.0
+        version: 5.48.0
       svelte-check:
         specifier: 4.3.5
-        version: 4.3.5(picomatch@4.0.3)(svelte@5.47.1)(typescript@5.9.3)
+        version: 4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3)
       test-fixture-factory:
         specifier: 2.1.0
         version: 2.1.0
@@ -145,10 +145,10 @@ importers:
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
+        version: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
       vitest:
         specifier: 4.0.17
-        version: 4.0.17(@types/node@25.0.9)(jiti@2.6.1)
+        version: 4.0.17(@types/node@25.0.10)(jiti@2.6.1)
 
 packages:
 
@@ -739,128 +739,128 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.55.3':
-    resolution: {integrity: sha512-qyX8+93kK/7R5BEXPC2PjUt0+fS/VO2BVHjEHyIEWiYn88rcRBHmdLgoJjktBltgAf+NY7RfCGB1SoyKS/p9kg==}
+  '@rollup/rollup-android-arm-eabi@4.56.0':
+    resolution: {integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.55.3':
-    resolution: {integrity: sha512-6sHrL42bjt5dHQzJ12Q4vMKfN+kUnZ0atHHnv4V0Wd9JMTk7FDzSY35+7qbz3ypQYMBPANbpGK7JpnWNnhGt8g==}
+  '@rollup/rollup-android-arm64@4.56.0':
+    resolution: {integrity: sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.55.3':
-    resolution: {integrity: sha512-1ht2SpGIjEl2igJ9AbNpPIKzb1B5goXOcmtD0RFxnwNuMxqkR6AUaaErZz+4o+FKmzxcSNBOLrzsICZVNYa1Rw==}
+  '@rollup/rollup-darwin-arm64@4.56.0':
+    resolution: {integrity: sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.55.3':
-    resolution: {integrity: sha512-FYZ4iVunXxtT+CZqQoPVwPhH7549e/Gy7PIRRtq4t5f/vt54pX6eG9ebttRH6QSH7r/zxAFA4EZGlQ0h0FvXiA==}
+  '@rollup/rollup-darwin-x64@4.56.0':
+    resolution: {integrity: sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.55.3':
-    resolution: {integrity: sha512-M/mwDCJ4wLsIgyxv2Lj7Len+UMHd4zAXu4GQ2UaCdksStglWhP61U3uowkaYBQBhVoNpwx5Hputo8eSqM7K82Q==}
+  '@rollup/rollup-freebsd-arm64@4.56.0':
+    resolution: {integrity: sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.55.3':
-    resolution: {integrity: sha512-5jZT2c7jBCrMegKYTYTpni8mg8y3uY8gzeq2ndFOANwNuC/xJbVAoGKR9LhMDA0H3nIhvaqUoBEuJoICBudFrA==}
+  '@rollup/rollup-freebsd-x64@4.56.0':
+    resolution: {integrity: sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
-    resolution: {integrity: sha512-YeGUhkN1oA+iSPzzhEjVPS29YbViOr8s4lSsFaZKLHswgqP911xx25fPOyE9+khmN6W4VeM0aevbDp4kkEoHiA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
+    resolution: {integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
-    resolution: {integrity: sha512-eo0iOIOvcAlWB3Z3eh8pVM8hZ0oVkK3AjEM9nSrkSug2l15qHzF3TOwT0747omI6+CJJvl7drwZepT+re6Fy/w==}
+  '@rollup/rollup-linux-arm-musleabihf@4.56.0':
+    resolution: {integrity: sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.3':
-    resolution: {integrity: sha512-DJay3ep76bKUDImmn//W5SvpjRN5LmK/ntWyeJs/dcnwiiHESd3N4uteK9FDLf0S0W8E6Y0sVRXpOCoQclQqNg==}
+  '@rollup/rollup-linux-arm64-gnu@4.56.0':
+    resolution: {integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.55.3':
-    resolution: {integrity: sha512-BKKWQkY2WgJ5MC/ayvIJTHjy0JUGb5efaHCUiG/39sSUvAYRBaO3+/EK0AZT1RF3pSj86O24GLLik9mAYu0IJg==}
+  '@rollup/rollup-linux-arm64-musl@4.56.0':
+    resolution: {integrity: sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.3':
-    resolution: {integrity: sha512-Q9nVlWtKAG7ISW80OiZGxTr6rYtyDSkauHUtvkQI6TNOJjFvpj4gcH+KaJihqYInnAzEEUetPQubRwHef4exVg==}
+  '@rollup/rollup-linux-loong64-gnu@4.56.0':
+    resolution: {integrity: sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.55.3':
-    resolution: {integrity: sha512-2H5LmhzrpC4fFRNwknzmmTvvyJPHwESoJgyReXeFoYYuIDfBhP29TEXOkCJE/KxHi27mj7wDUClNq78ue3QEBQ==}
+  '@rollup/rollup-linux-loong64-musl@4.56.0':
+    resolution: {integrity: sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
-    resolution: {integrity: sha512-9S542V0ie9LCTznPYlvaeySwBeIEa7rDBgLHKZ5S9DBgcqdJYburabm8TqiqG6mrdTzfV5uttQRHcbKff9lWtA==}
+  '@rollup/rollup-linux-ppc64-gnu@4.56.0':
+    resolution: {integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.3':
-    resolution: {integrity: sha512-ukxw+YH3XXpcezLgbJeasgxyTbdpnNAkrIlFGDl7t+pgCxZ89/6n1a+MxlY7CegU+nDgrgdqDelPRNQ/47zs0g==}
+  '@rollup/rollup-linux-ppc64-musl@4.56.0':
+    resolution: {integrity: sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
-    resolution: {integrity: sha512-Iauw9UsTTvlF++FhghFJjqYxyXdggXsOqGpFBylaRopVpcbfyIIsNvkf9oGwfgIcf57z3m8+/oSYTo6HutBFNw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.56.0':
+    resolution: {integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.3':
-    resolution: {integrity: sha512-3OqKAHSEQXKdq9mQ4eajqUgNIK27VZPW3I26EP8miIzuKzCJ3aW3oEn2pzF+4/Hj/Moc0YDsOtBgT5bZ56/vcA==}
+  '@rollup/rollup-linux-riscv64-musl@4.56.0':
+    resolution: {integrity: sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.3':
-    resolution: {integrity: sha512-0CM8dSVzVIaqMcXIFej8zZrSFLnGrAE8qlNbbHfTw1EEPnFTg1U1ekI0JdzjPyzSfUsHWtodilQQG/RA55berA==}
+  '@rollup/rollup-linux-s390x-gnu@4.56.0':
+    resolution: {integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.55.3':
-    resolution: {integrity: sha512-+fgJE12FZMIgBaKIAGd45rxf+5ftcycANJRWk8Vz0NnMTM5rADPGuRFTYar+Mqs560xuART7XsX2lSACa1iOmQ==}
+  '@rollup/rollup-linux-x64-gnu@4.56.0':
+    resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.55.3':
-    resolution: {integrity: sha512-tMD7NnbAolWPzQlJQJjVFh/fNH3K/KnA7K8gv2dJWCwwnaK6DFCYST1QXYWfu5V0cDwarWC8Sf/cfMHniNq21A==}
+  '@rollup/rollup-linux-x64-musl@4.56.0':
+    resolution: {integrity: sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.55.3':
-    resolution: {integrity: sha512-u5KsqxOxjEeIbn7bUK1MPM34jrnPwjeqgyin4/N6e/KzXKfpE9Mi0nCxcQjaM9lLmPcHmn/xx1yOjgTMtu1jWQ==}
+  '@rollup/rollup-openbsd-x64@4.56.0':
+    resolution: {integrity: sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.55.3':
-    resolution: {integrity: sha512-vo54aXwjpTtsAnb3ca7Yxs9t2INZg7QdXN/7yaoG7nPGbOBXYXQY41Km+S1Ov26vzOAzLcAjmMdjyEqS1JkVhw==}
+  '@rollup/rollup-openharmony-arm64@4.56.0':
+    resolution: {integrity: sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.3':
-    resolution: {integrity: sha512-HI+PIVZ+m+9AgpnY3pt6rinUdRYrGHvmVdsNQ4odNqQ/eRF78DVpMR7mOq7nW06QxpczibwBmeQzB68wJ+4W4A==}
+  '@rollup/rollup-win32-arm64-msvc@4.56.0':
+    resolution: {integrity: sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.3':
-    resolution: {integrity: sha512-vRByotbdMo3Wdi+8oC2nVxtc3RkkFKrGaok+a62AT8lz/YBuQjaVYAS5Zcs3tPzW43Vsf9J0wehJbUY5xRSekA==}
+  '@rollup/rollup-win32-ia32-msvc@4.56.0':
+    resolution: {integrity: sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.55.3':
-    resolution: {integrity: sha512-POZHq7UeuzMJljC5NjKi8vKMFN6/5EOqcX1yGntNLp7rUTpBAXQ1hW8kWPFxYLv07QMcNM75xqVLGPWQq6TKFA==}
+  '@rollup/rollup-win32-x64-gnu@4.56.0':
+    resolution: {integrity: sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.55.3':
-    resolution: {integrity: sha512-aPFONczE4fUFKNXszdvnd2GqKEYQdV5oEsIbKPujJmWlCI9zEsv1Otig8RKK+X9bed9gFUN6LAeN4ZcNuu4zjg==}
+  '@rollup/rollup-win32-x64-msvc@4.56.0':
+    resolution: {integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==}
     cpu: [x64]
     os: [win32]
 
@@ -958,8 +958,8 @@ packages:
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
-  '@types/node@25.0.9':
-    resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
+  '@types/node@25.0.10':
+    resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
 
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
@@ -1714,8 +1714,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2050,8 +2050,8 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rollup@4.55.3:
-    resolution: {integrity: sha512-y9yUpfQvetAjiDLtNMf1hL9NXchIJgWt6zIKeoB+tCd3npX08Eqfzg60V9DhIGVMtQ0AlMkFw5xa+AQ37zxnAA==}
+  rollup@4.56.0:
+    resolution: {integrity: sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2172,8 +2172,8 @@ packages:
       svelte:
         optional: true
 
-  svelte@5.47.1:
-    resolution: {integrity: sha512-MhSWfWEpG5T57z0Oyfk9D1GhAz/KTZKZZlWtGEsy9zNk2fafpuU7sJQlXNSA8HtvwKxVC9XlDyl5YovXUXjjHA==}
+  svelte@5.48.0:
+    resolution: {integrity: sha512-+NUe82VoFP1RQViZI/esojx70eazGF4u0O/9ucqZ4rPcOZD+n5EVp17uYsqwdzjUjZyTpGKunHbDziW6AIAVkQ==}
     engines: {node: '>=18'}
 
   svix@1.84.1:
@@ -2906,9 +2906,9 @@ snapshots:
 
   '@rocicorp/resolver@1.0.2': {}
 
-  '@rollup/plugin-commonjs@28.0.9(rollup@4.55.3)':
+  '@rollup/plugin-commonjs@28.0.9(rollup@4.56.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2916,105 +2916,105 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/plugin-json@6.1.0(rollup@4.55.3)':
+  '@rollup/plugin-json@6.1.0(rollup@4.56.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.55.3)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.56.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/pluginutils@5.3.0(rollup@4.55.3)':
+  '@rollup/pluginutils@5.3.0(rollup@4.56.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/rollup-android-arm-eabi@4.55.3':
+  '@rollup/rollup-android-arm-eabi@4.56.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.55.3':
+  '@rollup/rollup-android-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.55.3':
+  '@rollup/rollup-darwin-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.55.3':
+  '@rollup/rollup-darwin-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.55.3':
+  '@rollup/rollup-freebsd-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.55.3':
+  '@rollup/rollup-freebsd-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
+  '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
+  '@rollup/rollup-linux-arm-musleabihf@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.3':
+  '@rollup/rollup-linux-arm64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.55.3':
+  '@rollup/rollup-linux-arm64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.3':
+  '@rollup/rollup-linux-loong64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.55.3':
+  '@rollup/rollup-linux-loong64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
+  '@rollup/rollup-linux-ppc64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.3':
+  '@rollup/rollup-linux-ppc64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
+  '@rollup/rollup-linux-riscv64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.3':
+  '@rollup/rollup-linux-riscv64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.3':
+  '@rollup/rollup-linux-s390x-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.55.3':
+  '@rollup/rollup-linux-x64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.55.3':
+  '@rollup/rollup-linux-x64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.55.3':
+  '@rollup/rollup-openbsd-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.55.3':
+  '@rollup/rollup-openharmony-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.3':
+  '@rollup/rollup-win32-arm64-msvc@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.3':
+  '@rollup/rollup-win32-ia32-msvc@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.55.3':
+  '@rollup/rollup-win32-x64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.55.3':
+  '@rollup/rollup-win32-x64-msvc@4.56.0':
     optional: true
 
   '@roughapp/replimock@15.2.0(@electric-sql/pglite@0.3.15)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)':
@@ -3064,19 +3064,19 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-node@5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.47.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))':
+  '@sveltejs/adapter-node@5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))':
     dependencies:
-      '@rollup/plugin-commonjs': 28.0.9(rollup@4.55.3)
-      '@rollup/plugin-json': 6.1.0(rollup@4.55.3)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.55.3)
-      '@sveltejs/kit': 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.47.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
-      rollup: 4.55.3
+      '@rollup/plugin-commonjs': 28.0.9(rollup@4.56.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.56.0)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.56.0)
+      '@sveltejs/kit': 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      rollup: 4.56.0
 
-  '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.47.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))':
+  '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -3088,33 +3088,33 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
-      svelte: 5.47.1
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
+      svelte: 5.48.0
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       obug: 2.1.1
-      svelte: 5.47.1
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
+      svelte: 5.48.0
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.47.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.47.1
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+      svelte: 5.48.0
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+      vitefu: 1.1.1(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
 
-  '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.47.1)':
+  '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.48.0)':
     dependencies:
       html-to-text: 9.0.5
       pretty: 2.0.0
-      svelte: 5.47.1
+      svelte: 5.48.0
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -3138,13 +3138,13 @@ snapshots:
 
   '@types/node@14.18.63': {}
 
-  '@types/node@25.0.9':
+  '@types/node@25.0.10':
     dependencies:
       undici-types: 7.16.0
 
   '@types/pg@8.16.0':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 25.0.10
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
@@ -3152,7 +3152,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 25.0.10
 
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3254,13 +3254,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))':
+  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.0.17':
     dependencies:
@@ -3518,7 +3518,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-svelte@3.14.0(eslint@9.39.2(jiti@2.6.1))(svelte@5.47.1):
+  eslint-plugin-svelte@3.14.0(eslint@9.39.2(jiti@2.6.1))(svelte@5.48.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3530,9 +3530,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.6)
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
       semver: 7.7.3
-      svelte-eslint-parser: 1.4.1(svelte@5.47.1)
+      svelte-eslint-parser: 1.4.1(svelte@5.48.0)
     optionalDependencies:
-      svelte: 5.47.1
+      svelte: 5.48.0
     transitivePeerDependencies:
       - ts-node
 
@@ -3916,7 +3916,7 @@ snapshots:
       get-package-type: 0.1.0
       getopts: 2.3.0
       interpret: 2.2.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       pg-connection-string: 2.6.2
       rechoir: 0.8.0
       resolve-from: 5.0.0
@@ -3927,10 +3927,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  knip@5.82.1(@types/node@25.0.9)(typescript@5.9.3):
+  knip@5.82.1(@types/node@25.0.10)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      '@types/node': 25.0.9
+      '@types/node': 25.0.10
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.1
@@ -3969,7 +3969,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   lru-cache@10.4.3: {}
 
@@ -4264,35 +4264,35 @@ snapshots:
       glob: 13.0.0
       package-json-from-dist: 1.0.1
 
-  rollup@4.55.3:
+  rollup@4.56.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.55.3
-      '@rollup/rollup-android-arm64': 4.55.3
-      '@rollup/rollup-darwin-arm64': 4.55.3
-      '@rollup/rollup-darwin-x64': 4.55.3
-      '@rollup/rollup-freebsd-arm64': 4.55.3
-      '@rollup/rollup-freebsd-x64': 4.55.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.55.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.55.3
-      '@rollup/rollup-linux-arm64-gnu': 4.55.3
-      '@rollup/rollup-linux-arm64-musl': 4.55.3
-      '@rollup/rollup-linux-loong64-gnu': 4.55.3
-      '@rollup/rollup-linux-loong64-musl': 4.55.3
-      '@rollup/rollup-linux-ppc64-gnu': 4.55.3
-      '@rollup/rollup-linux-ppc64-musl': 4.55.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.55.3
-      '@rollup/rollup-linux-riscv64-musl': 4.55.3
-      '@rollup/rollup-linux-s390x-gnu': 4.55.3
-      '@rollup/rollup-linux-x64-gnu': 4.55.3
-      '@rollup/rollup-linux-x64-musl': 4.55.3
-      '@rollup/rollup-openbsd-x64': 4.55.3
-      '@rollup/rollup-openharmony-arm64': 4.55.3
-      '@rollup/rollup-win32-arm64-msvc': 4.55.3
-      '@rollup/rollup-win32-ia32-msvc': 4.55.3
-      '@rollup/rollup-win32-x64-gnu': 4.55.3
-      '@rollup/rollup-win32-x64-msvc': 4.55.3
+      '@rollup/rollup-android-arm-eabi': 4.56.0
+      '@rollup/rollup-android-arm64': 4.56.0
+      '@rollup/rollup-darwin-arm64': 4.56.0
+      '@rollup/rollup-darwin-x64': 4.56.0
+      '@rollup/rollup-freebsd-arm64': 4.56.0
+      '@rollup/rollup-freebsd-x64': 4.56.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.56.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.56.0
+      '@rollup/rollup-linux-arm64-gnu': 4.56.0
+      '@rollup/rollup-linux-arm64-musl': 4.56.0
+      '@rollup/rollup-linux-loong64-gnu': 4.56.0
+      '@rollup/rollup-linux-loong64-musl': 4.56.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.56.0
+      '@rollup/rollup-linux-ppc64-musl': 4.56.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.56.0
+      '@rollup/rollup-linux-riscv64-musl': 4.56.0
+      '@rollup/rollup-linux-s390x-gnu': 4.56.0
+      '@rollup/rollup-linux-x64-gnu': 4.56.0
+      '@rollup/rollup-linux-x64-musl': 4.56.0
+      '@rollup/rollup-openbsd-x64': 4.56.0
+      '@rollup/rollup-openharmony-arm64': 4.56.0
+      '@rollup/rollup-win32-arm64-msvc': 4.56.0
+      '@rollup/rollup-win32-ia32-msvc': 4.56.0
+      '@rollup/rollup-win32-x64-gnu': 4.56.0
+      '@rollup/rollup-win32-x64-msvc': 4.56.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -4380,19 +4380,19 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.47.1)(typescript@5.9.3):
+  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.47.1
+      svelte: 5.48.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.4.1(svelte@5.47.1):
+  svelte-eslint-parser@1.4.1(svelte@5.48.0):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -4401,9 +4401,9 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.6)
       postcss-selector-parser: 7.1.1
     optionalDependencies:
-      svelte: 5.47.1
+      svelte: 5.48.0
 
-  svelte@5.47.1:
+  svelte@5.48.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4499,27 +4499,27 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1):
+  vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.55.3
+      rollup: 4.56.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 25.0.10
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitefu@1.1.1(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)):
+  vitefu@1.1.1(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
 
-  vitest@4.0.17(@types/node@25.0.9)(jiti@2.6.1):
+  vitest@4.0.17(@types/node@25.0.10)(jiti@2.6.1):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -4536,10 +4536,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 25.0.10
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+blockExoticSubdeps: true
+
+minimumReleaseAge: 1440
+
+onlyBuiltDependencies:
+  - esbuild
+
+trustPolicy: no-downgrade

--- a/src/lib/components/LabelManager/Emoji.svelte
+++ b/src/lib/components/LabelManager/Emoji.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { onMount } from 'svelte'
+
+import { initEmojiMart } from '#lib/utils/emoji.js'
+
+type Props = {
+  scale?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
+  native: string
+  children?: never
+}
+
+const { scale = 1, native }: Props = $props()
+
+let isReady = $state(false)
+
+onMount(() => {
+  initEmojiMart()
+  isReady = true
+})
+</script>
+
+{#if isReady}
+  <em-emoji {native} style:font-size="var(--scale-{scale})"> </em-emoji>
+{/if}

--- a/src/lib/components/LabelManager/EmojiPicker.svelte
+++ b/src/lib/components/LabelManager/EmojiPicker.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+import type { Placement } from '@floating-ui/dom'
+import { flip, offset, shift } from '@floating-ui/dom'
+import { Picker } from 'emoji-mart'
+import type { Snippet } from 'svelte'
+
+import { createFloatingAttachment } from '#lib/utils/attachments/float.svelte.js'
+import { clickOutside } from '#lib/utils/attachments/outside.js'
+import { initEmojiMart } from '#lib/utils/emoji.js'
+
+type Emoji = {
+  native: string
+}
+
+type ToggleEmojiPickerFn = (event: Event) => void
+
+type Props = {
+  isOpen?: boolean
+  placement?: Placement
+  button?: Snippet<[ToggleEmojiPickerFn]>
+  onselect?: (emoji: string) => void
+}
+
+let {
+  isOpen = $bindable(false),
+  placement = 'right-start',
+  button,
+  onselect,
+}: Props = $props()
+
+let [anchor, floating] = $derived(
+  createFloatingAttachment({
+    placement,
+    middleware: [offset(8), flip(), shift()],
+  }),
+)
+
+let emojiRef: HTMLDivElement | undefined = $state(undefined)
+let emojiPicker: Node | undefined = $state(undefined)
+
+const hideEmojiPicker = () => {
+  isOpen = false
+  if (emojiRef && emojiPicker) {
+    // eslint-disable-next-line svelte/no-dom-manipulating
+    emojiRef.removeChild(emojiPicker)
+  }
+}
+
+const showEmojiPicker = () => {
+  isOpen = true
+  initEmojiMart()
+  requestAnimationFrame(() => {
+    emojiPicker = new Picker({
+      autoFocus: true,
+      onEmojiSelect: (emoji: Emoji, event: Event) => {
+        event.stopPropagation()
+        event.preventDefault()
+        onselect?.(emoji.native)
+        hideEmojiPicker()
+      },
+    }) as unknown as Node
+    // eslint-disable-next-line svelte/no-dom-manipulating
+    emojiRef?.appendChild(emojiPicker)
+  })
+}
+
+const toggleEmojiPicker: ToggleEmojiPickerFn = (event) => {
+  event.stopPropagation()
+  event.preventDefault()
+  if (isOpen) {
+    hideEmojiPicker()
+  } else {
+    showEmojiPicker()
+  }
+}
+</script>
+
+<div {@attach anchor}>
+  {#if button}
+    {@render button(toggleEmojiPicker)}
+  {:else}
+    <button type="button" onclick={toggleEmojiPicker}>
+      Change Icon
+    </button>
+  {/if}
+</div>
+
+{#if isOpen}
+  <div
+    class="emojiMart"
+    {@attach floating}
+    {@attach clickOutside(hideEmojiPicker)}
+    bind:this={emojiRef}></div>
+{/if}
+
+<style>
+  .emojiMart {
+    z-index: var(--layer-4);
+  }
+</style>

--- a/src/lib/components/LabelManager/LabelEditor.svelte
+++ b/src/lib/components/LabelManager/LabelEditor.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+import { tick } from 'svelte'
+import ColorPicker from 'svelte-awesome-color-picker'
+
+import type { Store } from '#lib/core/replicache/store.js'
+import type { LabelId } from '#lib/ids.js'
+import type { Label } from '#lib/types.local.js'
+
+import { query } from '#lib/utils/query.js'
+
+import Emoji from './Emoji.svelte'
+import EmojiPicker from './EmojiPicker.svelte'
+import SelectLabel from './SelectLabel.svelte'
+
+type Props = {
+  store: Store
+  labelId: LabelId
+  onsubmit?: (label: Label) => void
+}
+
+const { store, labelId, onsubmit }: Props = $props()
+
+const { label, stream } = $derived(
+  query(() => {
+    const label = store.label.get(labelId).value
+    const stream = label ? store.stream.get(label.streamId).value : undefined
+    return { label, stream }
+  }),
+)
+
+let parentId = $state<LabelId>()
+let color = $state<string>()
+let icon = $state<string>()
+let name = $state<string>('')
+
+let lastInitializedLabelId: LabelId | undefined
+$effect(() => {
+  if (label && label.id !== lastInitializedLabelId) {
+    parentId = label.parentId
+    color = label.color
+    icon = label.icon
+    name = label.name
+  }
+})
+
+const handleSubmit = async () => {
+  if (!label) {
+    return
+  }
+  if (parentId !== label.parentId) {
+    await store.mutate.label_setParent({ labelId, parentId })
+  }
+  if (name !== label.name) {
+    await store.mutate.label_rename({ labelId, name })
+  }
+  if (color !== label.color) {
+    await store.mutate.label_setColor({ labelId, color })
+  }
+  if (icon !== label.icon) {
+    await store.mutate.label_setIcon({ labelId, icon })
+  }
+
+  // by awaiting tick(), the `label` variable will be updated
+  // with the latest state
+  await tick()
+  onsubmit?.(label)
+}
+</script>
+
+<h2>Edit Label</h2>
+
+{#if label}
+  <div class="LabelEditor">
+    <div>
+      <label>Parent
+        {#if stream?.parentId}
+          <SelectLabel {store} streamId={stream.parentId} value={parentId} onchange={(value) => parentId = value} />
+        {:else}
+          <p>n/a</p>
+        {/if}
+      </label>
+    </div>
+
+    <div>
+      <label>Icon
+        <EmojiPicker onselect={(value) => icon = value}>
+          {#snippet button(toggle)}
+            <button type="button" onclick={toggle}>
+              {#if icon}<Emoji native={icon} scale={3} />{:else}Add Icon{/if}
+            </button>
+            {#if icon}<button type="button" onclick={() => icon = undefined}>Remove</button>{/if}
+          {/snippet}
+        </EmojiPicker>
+      </label>
+    </div>
+
+    <div>
+      <label>Name
+        <input type="text" name="name" bind:value={name} /></label>
+    </div>
+
+    <div>
+      <label>
+        Color
+        {#if color}
+          <ColorPicker hex={color} isAlpha={false} isDialog={false} onInput={(value) => color = (value.hex ?? undefined)} />
+          <button type="button" onclick={() => color =(undefined)}>Remove Color</button>
+        {:else}
+          <button type="button" onclick={() => color =('#fff')}>Set Color</button>
+        {/if}
+      </label>
+    </div>
+
+    <button onclick={handleSubmit}>Save</button>
+  </div>
+{:else}
+  <p>⚠️ Label not found</p>
+{/if}
+
+<style>
+  .LabelEditor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-2);
+  }
+</style>

--- a/src/lib/components/LabelManager/LabelList.svelte
+++ b/src/lib/components/LabelManager/LabelList.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+import type { ChangeEventHandler } from 'svelte/elements'
+
+import type { Store } from '#lib/core/replicache/store.js'
+import type { LabelId } from '#lib/ids.js'
+import type { Label } from '#lib/types.local.js'
+
+import Emoji from './Emoji.svelte'
+
+type Props = {
+  store: Store
+  parentLabel: Label | undefined
+  labelList: Label[]
+}
+
+const { parentLabel, labelList }: Props = $props()
+
+let selectedLabelIdList: LabelId[] = $state([])
+let selectedAll = $derived(selectedLabelIdList.length === labelList.length)
+
+const handleToggleAll: ChangeEventHandler<HTMLInputElement> = (event) => {
+  const { checked } = event.currentTarget
+
+  if (checked) {
+    selectedLabelIdList = labelList.map((label) => label.id)
+  } else {
+    selectedLabelIdList = []
+  }
+}
+</script>
+
+<section class="LabelList">
+  {#if parentLabel}
+    <h4 id="label-{parentLabel.id}">{parentLabel.icon ? parentLabel.icon + ' ' : ''}{parentLabel.name}</h4>
+  {/if}
+
+  <label>
+    <input
+      type="checkbox"
+      onchange={handleToggleAll}
+      checked={selectedAll}
+      autocomplete="off"
+    />
+    <strong>Select All</strong></label>
+
+  {#each labelList as label (label.id)}
+    <label style:--local-color={label.color}>
+      <div class="checkbox">
+        <input
+          type="checkbox"
+          name="label"
+          value={label.id}
+          bind:group={selectedLabelIdList}
+          autocomplete="off"
+        />
+      </div>
+      {#if label.icon}<Emoji native={label.icon} scale={3} />{/if}
+      <span>{label.name}</span>
+      <a href="/label/edit/{label.id}">Edit</a>
+    </label>
+  {/each}
+</section>
+
+<style>
+  .LabelList {
+    background: var(--color-grey-50);
+    padding: var(--size-4);
+    border-radius: var(--radius-sm);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-2);
+  }
+
+  label {
+    border-radius: var(--radius-sm);
+    background: color-mix(in lch, var(--local-color), transparent 80%);
+    display: flex;
+    gap: var(--size-2);
+    align-items: center;
+    height: var(--size-10);
+  }
+
+  .checkbox {
+    width: var(--size-10);
+    height: var(--size-10);
+    background: var(--local-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/src/lib/components/LabelManager/SelectLabel.svelte
+++ b/src/lib/components/LabelManager/SelectLabel.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+import type { ChangeEventHandler } from 'svelte/elements'
+
+import type { Store } from '#lib/core/replicache/store.js'
+import type { LabelId, StreamId } from '#lib/ids.js'
+
+import { getLabelListGroupedByParent } from '#lib/core/select/label.js'
+
+import { query } from '#lib/utils/query.js'
+
+type Props = {
+  store: Store
+  streamId: StreamId
+  value?: LabelId | undefined
+  onchange?: (value: LabelId | undefined) => void
+}
+
+const { store, streamId, value, onchange }: Props = $props()
+
+const { labelListGroupedByParent } = $derived(
+  query({
+    labelListGroupedByParent: getLabelListGroupedByParent(store, streamId),
+  }),
+)
+
+const handleChange: ChangeEventHandler<HTMLSelectElement> = (event) => {
+  const value = event.currentTarget.value
+  onchange?.(value === '' ? undefined : (value as LabelId))
+}
+</script>
+
+<select {value} onchange={handleChange}>
+  <option value=''>[No Parent]</option>
+  {#each labelListGroupedByParent as [parentLabel, labelList] (parentLabel?.id)}
+    {#if parentLabel}
+      <option disabled>{parentLabel.icon ? parentLabel.icon + ' ' : ''}{parentLabel.name}</option>
+    {/if}
+    {#each labelList as label (label.id)}
+      <option value={label.id}>{label.name}</option>
+    {/each}
+  {/each}
+</select>
+
+<style>
+  select {
+    display: block;
+    width: 100%;
+  }
+</style>

--- a/src/lib/components/LabelManager/StreamLabelManager.svelte
+++ b/src/lib/components/LabelManager/StreamLabelManager.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import type { Store } from '#lib/core/replicache/store.js'
+import type { StreamId } from '#lib/ids.js'
+
+import { getLabelListGroupedByParent } from '#lib/core/select/label.js'
+
+import { query } from '#lib/utils/query.js'
+
+import LabelList from './LabelList.svelte'
+
+type Props = {
+  store: Store
+  streamId: StreamId
+}
+
+const { store, streamId }: Props = $props()
+
+const { stream, groupedLabelList } = $derived(
+  query({
+    stream: store.stream.get(streamId),
+    groupedLabelList: getLabelListGroupedByParent(store, streamId),
+  }),
+)
+</script>
+
+<h3>{stream?.name ?? '⚠️ Missing'}</h3>
+
+{#each groupedLabelList as [parentLabel] (parentLabel?.id)}
+  {#if parentLabel}
+    <a href="#label-{parentLabel.id}">{parentLabel.icon ? parentLabel.icon + ' ' : ''}{parentLabel.name}</a>
+  {/if}
+{/each}
+
+{#each groupedLabelList as [parentLabel, labelList] (parentLabel?.id)}
+  <LabelList {store} {parentLabel} {labelList} />
+{/each}

--- a/src/lib/components/StreamManager/StreamListItem.svelte
+++ b/src/lib/components/StreamManager/StreamListItem.svelte
@@ -23,7 +23,8 @@ const { streamList } = $derived(
 const handleSetParentStream: ChangeEventHandler<HTMLSelectElement> = async (
   event,
 ) => {
-  const parentId = event.currentTarget.value as StreamId | undefined
+  const value = event.currentTarget.value
+  const parentId = value === '' ? undefined : (value as StreamId)
   await store.mutate.stream_setParent({
     streamId: stream.id,
     parentId,

--- a/src/lib/core/select/label.ts
+++ b/src/lib/core/select/label.ts
@@ -1,17 +1,20 @@
+import type { Signal } from 'signia'
 import { computed } from 'signia'
 
-import type { StreamId } from '#lib/ids.js'
+import type { LabelId, StreamId } from '#lib/ids.js'
+import type { Label } from '#lib/types.local.js'
 
+import { groupBy } from '#lib/utils/group-by.js'
 import { createSelector } from '#lib/utils/selector.js'
 
-const getLabelListForStream = createSelector(
-  'getLabelListForStream',
-  (store, streamId: StreamId) => {
+const getLabelList = createSelector(
+  'getLabelList',
+  (store, streamId: StreamId): Signal<Label[]> => {
     const $filteredLabelList = store.label.filter((value) => {
       return value.streamId === streamId
     })
 
-    return computed('getLabelListForStream', () => {
+    return computed('getLabelList', () => {
       return $filteredLabelList.value.toSorted((a, b) => {
         return a.name.localeCompare(b.name)
       })
@@ -19,4 +22,38 @@ const getLabelListForStream = createSelector(
   },
 )
 
-export { getLabelListForStream }
+const getLabelListGroupedByParent = createSelector(
+  'getParentLabelList',
+  (
+    store,
+    streamId: StreamId,
+  ): Signal<(readonly [Label | undefined, Label[]])[]> => {
+    const $labelList = getLabelList(store, streamId)
+
+    return computed('getParentLabelList', () => {
+      const labelList = $labelList.value
+
+      const groupedList = groupBy(labelList, (label) => {
+        return label.parentId ?? ''
+      })
+
+      const parentLabelList = Object.entries(groupedList)
+        .map(([parentId, labelList]) => {
+          if (parentId === '') {
+            return [undefined, labelList] as const
+          }
+          const parentLabel = store.label.get(parentId as LabelId).value
+          return [parentLabel, labelList] as const
+        })
+        .sort((a, b) => {
+          const aName = a[0]?.name ?? ''
+          const bName = b[0]?.name ?? ''
+          return aName.localeCompare(bName)
+        })
+
+      return parentLabelList
+    })
+  },
+)
+
+export { getLabelList, getLabelListGroupedByParent }

--- a/src/lib/mutator/index.server.ts
+++ b/src/lib/mutator/index.server.ts
@@ -10,6 +10,10 @@ const mutators: ServerMutatorDefsImportMap = {
   stream_delete: import('./stream-delete.server.js'),
 
   label_create: import('./label-create.server.js'),
+  label_rename: import('./label-rename.server.js'),
+  label_setParent: import('./label-set-parent.server.js'),
+  label_setColor: import('./label-set-color.server.js'),
+  label_setIcon: import('./label-set-icon.server.js'),
 
   point_create: import('./point-create.server.js'),
   point_slide: import('./point-slide.server.js'),

--- a/src/lib/mutator/index.ts
+++ b/src/lib/mutator/index.ts
@@ -10,6 +10,10 @@ const mutators: LocalMutatorDefsImportMap = {
   stream_delete: import('./stream-delete.js'),
 
   label_create: import('./label-create.js'),
+  label_rename: import('./label-rename.js'),
+  label_setParent: import('./label-set-parent.js'),
+  label_setColor: import('./label-set-color.js'),
+  label_setIcon: import('./label-set-icon.js'),
 
   point_create: import('./point-create.js'),
   point_slide: import('./point-slide.js'),

--- a/src/lib/mutator/label-create.server.ts
+++ b/src/lib/mutator/label-create.server.ts
@@ -7,7 +7,7 @@ const label_create: ServerMutator<'label_create'> = async (
   options,
 ) => {
   const { db, sessionUserId } = context
-  const { labelId, streamId, name, icon, color } = options
+  const { labelId, streamId, parentId, name, icon, color } = options
 
   const label = await insertLabel({
     db,
@@ -16,9 +16,9 @@ const label_create: ServerMutator<'label_create'> = async (
       userId: sessionUserId,
       streamId,
       name,
+      parentId: parentId ?? null,
       icon: icon ?? null,
       color: color ?? null,
-      parentId: null,
     },
   })
   if (label instanceof Error) {

--- a/src/lib/mutator/label-create.ts
+++ b/src/lib/mutator/label-create.ts
@@ -7,7 +7,7 @@ import { deleteUndefinedKeys } from '#lib/utils/delete-undefined-keys.js'
 
 const labelCreate: LocalMutator<'label_create'> = async (context, options) => {
   const { tx, actionedAt } = context
-  const { labelId, streamId, name, color, icon } = options
+  const { labelId, streamId, parentId, name, color, icon } = options
 
   const key = Key.label.encode(labelId)
   const value: AnonLabel = deleteUndefinedKeys({
@@ -15,7 +15,7 @@ const labelCreate: LocalMutator<'label_create'> = async (context, options) => {
     streamId,
     color,
     icon,
-    parentId: undefined,
+    parentId,
     createdAt: actionedAt,
     updatedAt: actionedAt,
   })

--- a/src/lib/mutator/label-rename.server.ts
+++ b/src/lib/mutator/label-rename.server.ts
@@ -1,0 +1,24 @@
+import type { ServerMutator } from './types.ts'
+
+import { updateLabel } from '#lib/server/db/label/update-label.js'
+
+const labelRename: ServerMutator<'label_rename'> = async (context, options) => {
+  const { db } = context
+  const { labelId, name } = options
+
+  const result = await updateLabel({
+    db,
+    where: {
+      userId: context.sessionUserId,
+      labelId,
+    },
+    set: {
+      name,
+    },
+  })
+  if (result instanceof Error) {
+    return result
+  }
+}
+
+export default labelRename

--- a/src/lib/mutator/label-rename.ts
+++ b/src/lib/mutator/label-rename.ts
@@ -1,0 +1,24 @@
+import type { AnonLabel } from '#lib/core/replicache/types.js'
+import type { LocalMutator } from './types.ts'
+
+import * as Key from '#lib/core/replicache/keys.js'
+
+const labelRename: LocalMutator<'label_rename'> = async (context, options) => {
+  const { tx, actionedAt } = context
+  const { labelId, name } = options
+
+  const key = Key.label.encode(labelId)
+  const label = await tx.get<AnonLabel>(key)
+  if (!label) {
+    return new Error('Label not found')
+  }
+
+  const value: AnonLabel = {
+    ...label,
+    name,
+    updatedAt: actionedAt,
+  }
+  await tx.set(key, value)
+}
+
+export default labelRename

--- a/src/lib/mutator/label-set-color.server.ts
+++ b/src/lib/mutator/label-set-color.server.ts
@@ -1,0 +1,27 @@
+import type { ServerMutator } from './types.ts'
+
+import { updateLabel } from '#lib/server/db/label/update-label.js'
+
+const labelSetColor: ServerMutator<'label_setColor'> = async (
+  context,
+  options,
+) => {
+  const { db } = context
+  const { labelId, color } = options
+
+  const result = await updateLabel({
+    db,
+    where: {
+      userId: context.sessionUserId,
+      labelId,
+    },
+    set: {
+      color: color ?? null,
+    },
+  })
+  if (result instanceof Error) {
+    return result
+  }
+}
+
+export default labelSetColor

--- a/src/lib/mutator/label-set-color.ts
+++ b/src/lib/mutator/label-set-color.ts
@@ -1,0 +1,27 @@
+import type { AnonLabel } from '#lib/core/replicache/types.js'
+import type { LocalMutator } from './types.ts'
+
+import * as Key from '#lib/core/replicache/keys.js'
+
+const labelSetColor: LocalMutator<'label_setColor'> = async (
+  context,
+  options,
+) => {
+  const { tx, actionedAt } = context
+  const { labelId, color } = options
+
+  const key = Key.label.encode(labelId)
+  const label = await tx.get<AnonLabel>(key)
+  if (!label) {
+    return new Error('Label not found')
+  }
+
+  const value: AnonLabel = {
+    ...label,
+    color,
+    updatedAt: actionedAt,
+  }
+  await tx.set(key, value)
+}
+
+export default labelSetColor

--- a/src/lib/mutator/label-set-icon.server.ts
+++ b/src/lib/mutator/label-set-icon.server.ts
@@ -1,0 +1,27 @@
+import type { ServerMutator } from './types.ts'
+
+import { updateLabel } from '#lib/server/db/label/update-label.js'
+
+const labelSetIcon: ServerMutator<'label_setIcon'> = async (
+  context,
+  options,
+) => {
+  const { db } = context
+  const { labelId, icon } = options
+
+  const result = await updateLabel({
+    db,
+    where: {
+      userId: context.sessionUserId,
+      labelId,
+    },
+    set: {
+      icon: icon ?? null,
+    },
+  })
+  if (result instanceof Error) {
+    return result
+  }
+}
+
+export default labelSetIcon

--- a/src/lib/mutator/label-set-icon.ts
+++ b/src/lib/mutator/label-set-icon.ts
@@ -1,0 +1,27 @@
+import type { AnonLabel } from '#lib/core/replicache/types.js'
+import type { LocalMutator } from './types.ts'
+
+import * as Key from '#lib/core/replicache/keys.js'
+
+const labelSetIcon: LocalMutator<'label_setIcon'> = async (
+  context,
+  options,
+) => {
+  const { tx, actionedAt } = context
+  const { labelId, icon } = options
+
+  const key = Key.label.encode(labelId)
+  const label = await tx.get<AnonLabel>(key)
+  if (!label) {
+    return new Error('Label not found')
+  }
+
+  const value: AnonLabel = {
+    ...label,
+    icon,
+    updatedAt: actionedAt,
+  }
+  await tx.set(key, value)
+}
+
+export default labelSetIcon

--- a/src/lib/mutator/label-set-parent.server.ts
+++ b/src/lib/mutator/label-set-parent.server.ts
@@ -1,19 +1,19 @@
 import type { ServerMutator } from './types.ts'
 
-import { updateStream } from '#lib/server/db/stream/update-stream.js'
+import { updateLabel } from '#lib/server/db/label/update-label.js'
 
-const streamSetParent: ServerMutator<'stream_setParent'> = async (
+const labelSetParent: ServerMutator<'label_setParent'> = async (
   context,
   options,
 ) => {
   const { db } = context
-  const { streamId, parentId } = options
+  const { labelId, parentId } = options
 
-  const result = await updateStream({
+  const result = await updateLabel({
     db,
     where: {
       userId: context.sessionUserId,
-      streamId,
+      labelId,
     },
     set: {
       parentId: parentId ?? null,
@@ -24,4 +24,4 @@ const streamSetParent: ServerMutator<'stream_setParent'> = async (
   }
 }
 
-export default streamSetParent
+export default labelSetParent

--- a/src/lib/mutator/label-set-parent.ts
+++ b/src/lib/mutator/label-set-parent.ts
@@ -1,0 +1,27 @@
+import type { AnonLabel } from '#lib/core/replicache/types.js'
+import type { LocalMutator } from './types.ts'
+
+import * as Key from '#lib/core/replicache/keys.js'
+
+const labelSetParent: LocalMutator<'label_setParent'> = async (
+  context,
+  options,
+) => {
+  const { tx, actionedAt } = context
+  const { labelId, parentId } = options
+
+  const key = Key.label.encode(labelId)
+  const label = await tx.get<AnonLabel>(key)
+  if (!label) {
+    return new Error('Label not found')
+  }
+
+  const value: AnonLabel = {
+    ...label,
+    parentId,
+    updatedAt: actionedAt,
+  }
+  await tx.set(key, value)
+}
+
+export default labelSetParent

--- a/src/lib/mutator/types.ts
+++ b/src/lib/mutator/types.ts
@@ -15,8 +15,25 @@ type Mutators = {
   label_create: Mutator<{
     labelId: LabelId
     streamId: StreamId
+    parentId: LabelId | undefined
     name: string
     color: string | undefined
+    icon: string | undefined
+  }>
+  label_rename: Mutator<{
+    labelId: LabelId
+    name: string
+  }>
+  label_setParent: Mutator<{
+    labelId: LabelId
+    parentId: LabelId | undefined
+  }>
+  label_setColor: Mutator<{
+    labelId: LabelId
+    color: string | undefined
+  }>
+  label_setIcon: Mutator<{
+    labelId: LabelId
     icon: string | undefined
   }>
 

--- a/src/lib/server/db/label/update-label.ts
+++ b/src/lib/server/db/label/update-label.ts
@@ -1,0 +1,39 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+
+import type { LabelId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { Label } from '#lib/server/types.js'
+
+type UpdateLabelOptions = {
+  db: KyselyDb
+  where: {
+    userId: UserId
+    labelId: LabelId
+  }
+  set: Partial<Pick<Label, 'name' | 'parentId' | 'color' | 'icon'>>
+  now?: number
+}
+
+const updateLabel = async (
+  options: UpdateLabelOptions,
+): Promise<Label | Error> => {
+  const { db, set, now = Date.now() } = options
+
+  return errorBoundary(() =>
+    db
+      .updateTable('label')
+      .set({
+        name: set.name,
+        parentId: set.parentId,
+        color: set.color,
+        icon: set.icon,
+        updatedAt: now,
+      })
+      .where('id', '=', options.where.labelId)
+      .where('userId', '=', options.where.userId)
+      .returningAll()
+      .executeTakeFirstOrThrow(),
+  )
+}
+
+export { updateLabel }

--- a/src/lib/server/worker.ts
+++ b/src/lib/server/worker.ts
@@ -30,7 +30,7 @@ const initBoss = () => {
       await garbageCollectEmailVerification({ db })
     })
 
-    await boss.schedule(GC_EMAIL_VERIFICATION, '* * * * *')
+    await boss.schedule(GC_EMAIL_VERIFICATION, '0 0 * * *')
   })().catch((error) => {
     console.error('[worker] Failed to start worker', error)
   })

--- a/src/lib/utils/attachments/float.svelte.ts
+++ b/src/lib/utils/attachments/float.svelte.ts
@@ -1,0 +1,70 @@
+import type { ComputePositionConfig } from '@floating-ui/dom'
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+} from '@floating-ui/dom'
+import type { Attachment } from 'svelte/attachments'
+
+const defaultConfig: ComputePositionConfig = {
+  placement: 'bottom-start',
+  strategy: 'absolute',
+  middleware: [offset(4), flip(), shift()],
+}
+
+const createFloatingAttachment = (userConfig?: ComputePositionConfig) => {
+  const config = { ...defaultConfig, ...userConfig }
+
+  let referenceEl = $state<HTMLElement>()
+  let floatingEl = $state<HTMLElement>()
+
+  const attachReference: Attachment<HTMLElement> = (node) => {
+    referenceEl = node
+
+    return () => {
+      referenceEl = undefined
+    }
+  }
+
+  const attachFloating: Attachment<HTMLElement> = (node) => {
+    floatingEl = node
+
+    return () => {
+      floatingEl = undefined
+    }
+  }
+
+  $effect(() => {
+    if (!referenceEl || !floatingEl) {
+      return
+    }
+
+    const cleanup = autoUpdate(referenceEl, floatingEl, () => {
+      if (!referenceEl || !floatingEl) {
+        return
+      }
+
+      const { style } = floatingEl
+      void computePosition(referenceEl, floatingEl, config).then(
+        (v) => {
+          style.position = v.strategy
+          style.left = `${v.x}px`
+          style.top = `${v.y}px`
+        },
+        (error) => {
+          console.error('Error computing position for floating element:', error)
+        },
+      )
+    })
+
+    return () => {
+      cleanup()
+    }
+  })
+
+  return [attachReference, attachFloating] as const
+}
+
+export { createFloatingAttachment }

--- a/src/lib/utils/attachments/outside.ts
+++ b/src/lib/utils/attachments/outside.ts
@@ -1,0 +1,35 @@
+import type { Attachment } from 'svelte/attachments'
+
+const isNode = (node: unknown): node is Node => {
+  return typeof node === 'object' && node !== null && 'nodeType' in node
+}
+
+const eventOutside = <EventType extends keyof DocumentEventMap>(
+  eventType: EventType,
+  onEventOutside: (event: DocumentEventMap[EventType]) => void,
+): Attachment<HTMLElement> => {
+  return (node: Node) => {
+    const handleEvent = (event: DocumentEventMap[EventType]) => {
+      if (
+        node &&
+        isNode(event.target) &&
+        !node.contains(event.target) &&
+        !event.defaultPrevented
+      ) {
+        onEventOutside(event)
+      }
+    }
+    document.addEventListener(eventType, handleEvent, true)
+
+    return () => {
+      // cleanup when component is unmounted
+      document.removeEventListener(eventType, handleEvent, true)
+    }
+  }
+}
+
+const clickOutside = (onEventOutside: (event: MouseEvent) => void) => {
+  return eventOutside('click', onEventOutside)
+}
+
+export { clickOutside }

--- a/src/lib/utils/emoji.ts
+++ b/src/lib/utils/emoji.ts
@@ -1,0 +1,10 @@
+import data from '@emoji-mart/data'
+import * as emojiMart from 'emoji-mart'
+
+import { once } from '#lib/utils/once.js'
+
+const initEmojiMart = once(() => {
+  return emojiMart.init({ data })
+})
+
+export { initEmojiMart }

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -32,6 +32,7 @@ afterNavigate(() => {
     <div class="menuContainer">
       <a href="/add">Add</a>
       <a href="/log">Log</a>
+      <a href="/label">Labels</a>
       <a href="/settings">Settings</a>
     </div>
     <button class="menuToggle" aria-hidden="true" onclick={toggleMenuOpen}>Menu</button>

--- a/src/routes/(app)/add/PointInput.svelte
+++ b/src/routes/(app)/add/PointInput.svelte
@@ -6,7 +6,7 @@ import type { Store } from '#lib/core/replicache/store.js'
 import type { LabelId } from '#lib/ids.js'
 import type { Stream } from '#lib/types.local.js'
 
-import { getLabelListForStream } from '#lib/core/select/label.js'
+import { getLabelList } from '#lib/core/select/label.js'
 
 import { query } from '#lib/utils/query.js'
 
@@ -44,7 +44,7 @@ onMount(() => {
 
 const { streamLabelList } = $derived(
   query({
-    streamLabelList: getLabelListForStream(store, stream.id),
+    streamLabelList: getLabelList(store, stream.id),
   }),
 )
 

--- a/src/routes/(app)/add/submit.ts
+++ b/src/routes/(app)/add/submit.ts
@@ -35,6 +35,7 @@ const handleFormSubmit = async (options: HandleFormSubmitOptions) => {
           name: label.name,
           color: undefined,
           icon: undefined,
+          parentId: undefined,
         })
         return labelId
       }),

--- a/src/routes/(app)/label/+page.ts
+++ b/src/routes/(app)/label/+page.ts
@@ -1,0 +1,9 @@
+import { redirect } from '@sveltejs/kit'
+
+import type { PageLoad } from './$types'
+
+const load = (async (_event) => {
+  throw redirect(302, '/label/stream')
+}) satisfies PageLoad
+
+export { load }

--- a/src/routes/(app)/label/edit/[labelId]/+page.svelte
+++ b/src/routes/(app)/label/edit/[labelId]/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import type { LabelId } from '#lib/ids.js'
+import type { Label } from '#lib/types.local.js'
+import type { PageProps } from './$types'
+
+import { goto } from '$app/navigation'
+import { page } from '$app/state'
+
+import LabelEditor from '#lib/components/LabelManager/LabelEditor.svelte'
+
+const { data }: PageProps = $props()
+const { store } = $derived(data)
+
+const labelId = $derived(page.params.labelId as LabelId)
+
+const handleSubmit = (label: Label) => {
+  goto(`/label/stream/${label.streamId}`)
+}
+</script>
+
+<main>
+  <LabelEditor {store} {labelId} onsubmit={handleSubmit} />
+</main>
+
+<style>
+  main {
+    max-width: var(--width-xs);
+    margin-inline: auto;
+  }
+</style>

--- a/src/routes/(app)/label/stream/+layout.svelte
+++ b/src/routes/(app)/label/stream/+layout.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import type { StreamId } from '#lib/ids.js'
+import type { LayoutProps } from './$types.js'
+
+import { page } from '$app/state'
+
+const { data, children }: LayoutProps = $props()
+const { store } = $derived(data)
+
+import { getStreamList } from '#lib/core/select/stream.js'
+
+import { query } from '#lib/utils/query.js'
+
+const { streamList } = $derived(
+  query({
+    streamList: getStreamList(store),
+  }),
+)
+
+const activeStreamId = $derived(page.params.streamId as StreamId)
+</script>
+
+<h2>Labels</h2>
+
+<nav>
+  {#each streamList as stream (stream.id)}
+    <a href="/label/stream/{stream.id}" class:isActive={stream.id === activeStreamId}>{stream.name}</a>
+  {/each}
+</nav>
+
+{@render children?.()}
+
+<style>
+	nav {
+		display: flex;
+		gap: var(--size-2);
+
+    a {
+      display: block;
+      padding: var(--size-2) var(--size-3);
+      border-radius: var(--radius-xs);
+      background-color: var(--theme-background);
+      color: var(--theme-text-main);
+      text-decoration: none;
+
+      &:hover {
+        background-color: var(--theme-background-alt);
+      }
+
+      &.isActive {
+        background-color: var(--theme-button-base);
+        color: var(--theme-text-bright);
+
+        &:hover {
+          background-color: var(--theme-button-hover);
+        }
+      }
+    }
+	}
+</style>

--- a/src/routes/(app)/label/stream/+page.ts
+++ b/src/routes/(app)/label/stream/+page.ts
@@ -1,0 +1,19 @@
+import { redirect } from '@sveltejs/kit'
+
+import type { PageLoad } from './$types'
+
+import { getStreamList } from '#lib/core/select/stream.js'
+
+const load = (async (event) => {
+  const { parent } = event
+  const { store } = await parent()
+
+  const streamList = getStreamList(store).value
+  const streamId = streamList.at(0)?.id
+
+  if (streamId) {
+    redirect(302, `/label/stream/${streamId}`)
+  }
+}) satisfies PageLoad
+
+export { load }

--- a/src/routes/(app)/label/stream/[streamId]/+page.svelte
+++ b/src/routes/(app)/label/stream/[streamId]/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import type { StreamId } from '#lib/ids.js'
+import type { PageProps } from './$types.js'
+
+import { page } from '$app/state'
+
+import StreamLabelManager from '#lib/components/LabelManager/StreamLabelManager.svelte'
+
+const { data }: PageProps = $props()
+const { store } = $derived(data)
+
+const streamId = $derived(page.params.streamId as StreamId)
+</script>
+
+<StreamLabelManager {store} {streamId} />


### PR DESCRIPTION
## Summary
Add a label management feature with emoji support, including UI pages/components, local+server mutators, utilities for emoji & floating attachments, and dependency updates to support the new UX.

## Changes
- UI: add a Labels section and full label-management UI under /label (pages and components): LabelEditor, LabelList, SelectLabel, StreamLabelManager, Emoji, EmojiPicker.
- Mutators & server: add local and server mutators for label_rename, label_setParent, label_setColor, label_setIcon and wire them into the mutator maps; introduce updateLabel DB helper.
- Emoji & floating UI: add emoji-mart integration and floating-ui-based attachment helpers (createFloatingAttachment, clickOutside) plus an emoji init util.
- Routing/layout: add label routes (/label/stream, edit pages) and a menu link; PointInput now uses the refactored getLabelList selector.
- Tooling & deps: package.json/pnpm-lock changes to add emoji-mart, @floating-ui/dom, svelte-awesome-color-picker and bump svelte/@types/node/lodash; pnpm-workspace.yaml and lockfile updated.
- Infra: worker GC schedule changed from every minute to daily (cron changed to '0 0 * * *').

## Notes / Breaking changes
- label_create now accepts and persists parentId; server must be deployed with the new mutators and DB helper. If your DB schema lacks parentId/color/icon columns or the new server mutators, label-related actions may fail — deploy server and run any required migrations before rolling out the frontend.
- Dependency updates include svelte -> 5.48.0 and related resolution changes; test local builds after installing dependencies. The pnpm workspace trustPolicy and onlyBuiltDependencies entries were added/modified and may affect installs.
- Behavioural change: email verification GC runs daily instead of every minute.