### PR TITLE
feat(db): add stream_id to point_label and label-parent migration

### DIFF
--- a/migrations/committed/000004.sql
+++ b/migrations/committed/000004.sql
@@ -1,0 +1,57 @@
+--! Previous: sha1:2782857bd76fb0454f16b6954085e83cb39d43f9
+--! Hash: sha1:af4fa9b2b3a9c3380f8f3d5480ecfdde3bca993f
+
+--
+-- add stream_id to point_label
+-- and ensure that points can only have labels from the same stream
+--
+
+-- idempotent reset
+ALTER TABLE ONLY public.point_label
+  DROP CONSTRAINT IF EXISTS "point_label:foreignKey(stream_id)",
+  DROP CONSTRAINT IF EXISTS "point_label:foreignKey(label_id)",
+  DROP CONSTRAINT IF EXISTS "point_label:foreignKey(point_id)",
+  DROP COLUMN IF EXISTS stream_id;
+ALTER TABLE ONLY public.point
+  DROP CONSTRAINT IF EXISTS "point:unique(id,stream_id)";
+ALTER TABLE ONLY public.label
+  DROP CONSTRAINT IF EXISTS "label:unique(id,stream_id)";
+
+ALTER TABLE ONLY public.point_label
+  ADD COLUMN stream_id TEXT;
+
+-- backfill stream_id with the point.stream_id
+UPDATE public.point_label
+  SET stream_id = point.stream_id
+  FROM public.point
+  WHERE TRUE
+    AND point.id = point_label.point_id
+    AND point_label.stream_id IS NULL;
+
+-- ensure that stream_id is not null
+ALTER TABLE ONLY public.point_label
+  ALTER COLUMN stream_id SET NOT NULL;
+
+-- first, we need to setup unique indexes on point and label tables
+ALTER TABLE ONLY public.point
+  ADD CONSTRAINT "point:unique(id,stream_id)"
+    UNIQUE (id, stream_id);
+ALTER TABLE ONLY public.label
+  ADD CONSTRAINT "label:unique(id,stream_id)"
+    UNIQUE (id, stream_id);
+
+-- now, we can add composite foreign keys
+-- to ensure that points can only have labels from the same stream
+ALTER TABLE ONLY public.point_label
+  ADD CONSTRAINT "point_label:foreignKey(stream_id)"
+    FOREIGN KEY (stream_id)
+    REFERENCES public.stream (id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD CONSTRAINT "point_label:foreignKey(label_id)"
+    FOREIGN KEY (label_id, stream_id)
+    REFERENCES public.label (id, stream_id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD CONSTRAINT "point_label:foreignKey(point_id)"
+    FOREIGN KEY (point_id, stream_id)
+    REFERENCES public.point (id, stream_id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT;

--- a/migrations/committed/000005.sql
+++ b/migrations/committed/000005.sql
@@ -1,0 +1,73 @@
+--! Previous: sha1:af4fa9b2b3a9c3380f8f3d5480ecfdde3bca993f
+--! Hash: sha1:54c93b8fa94f452d73ade53ac43855adbc0f8cf3
+
+-- idempotent reset
+ALTER TABLE ONLY public.label
+  DROP CONSTRAINT IF EXISTS "label:foreignKey(parent_id)",
+  DROP CONSTRAINT IF EXISTS "label:foreignKey(stream_id)",
+  DROP CONSTRAINT IF EXISTS "label:foreignKey(user_id)";
+ALTER TABLE ONLY public.point
+  DROP CONSTRAINT IF EXISTS "point:foreignKey(stream_id)",
+  DROP CONSTRAINT IF EXISTS "point:foreignKey(user_id)";
+ALTER TABLE ONLY public.replicache_client
+  DROP CONSTRAINT IF EXISTS "replicache_client:foreignKey(replicache_client_group_id)";
+ALTER TABLE ONLY public.replicache_client_group
+  DROP CONSTRAINT IF EXISTS "replicache_client_group:foreignKey(user_id)";
+ALTER TABLE ONLY public.stream
+  DROP CONSTRAINT IF EXISTS "stream:foreignKey(parent_id)",
+  DROP CONSTRAINT IF EXISTS "stream:foreignKey(user_id)";
+ALTER TABLE ONLY public.user_session
+  DROP CONSTRAINT IF EXISTS "user_session:foreignKey(user_id,user)";
+
+-- update all existing foreign keys to be on update/delete restrict
+ALTER TABLE ONLY public.label
+  ADD CONSTRAINT "label:foreignKey(parent_id)"
+    FOREIGN KEY (parent_id, user_id)
+    REFERENCES public.label(id, user_id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD CONSTRAINT "label:foreignKey(stream_id)"
+    FOREIGN KEY (stream_id, user_id)
+    REFERENCES public.stream(id, user_id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD CONSTRAINT "label:foreignKey(user_id)"
+    FOREIGN KEY (user_id)
+    REFERENCES public."user"(id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.point
+  ADD CONSTRAINT "point:foreignKey(stream_id)"
+    FOREIGN KEY (stream_id, user_id)
+    REFERENCES public.stream(id, user_id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD CONSTRAINT "point:foreignKey(user_id)"
+    FOREIGN KEY (user_id)
+    REFERENCES public."user"(id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.replicache_client
+  ADD CONSTRAINT "replicache_client:foreignKey(replicache_client_group_id)"
+    FOREIGN KEY (replicache_client_group_id)
+    REFERENCES public.replicache_client_group(id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.replicache_client_group
+  ADD CONSTRAINT "replicache_client_group:foreignKey(user_id)"
+    FOREIGN KEY (user_id) 
+    REFERENCES public."user"(id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.stream
+  ADD CONSTRAINT "stream:foreignKey(parent_id)"
+    FOREIGN KEY (parent_id, user_id)
+    REFERENCES public.stream(id, user_id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD CONSTRAINT "stream:foreignKey(user_id)"
+    FOREIGN KEY (user_id)
+    REFERENCES public."user"(id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.user_session
+  ADD CONSTRAINT "user_session:foreignKey(user_id,user)"
+    FOREIGN KEY (user_id)
+    REFERENCES public."user"(id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT;

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -80,7 +80,8 @@ CREATE TABLE public.point_label (
     user_id text NOT NULL,
     sort_order integer NOT NULL,
     created_at bigint NOT NULL,
-    updated_at bigint NOT NULL
+    updated_at bigint NOT NULL,
+    stream_id text NOT NULL
 );
 
 
@@ -199,6 +200,14 @@ ALTER TABLE ONLY public.label
 
 
 --
+-- Name: label label:unique(id,stream_id); Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.label
+    ADD CONSTRAINT "label:unique(id,stream_id)" UNIQUE (id, stream_id);
+
+
+--
 -- Name: label label:unique(id,user_id); Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -212,6 +221,14 @@ ALTER TABLE ONLY public.label
 
 ALTER TABLE ONLY public.point
     ADD CONSTRAINT "point:primaryKey(id)" PRIMARY KEY (id);
+
+
+--
+-- Name: point point:unique(id,stream_id); Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.point
+    ADD CONSTRAINT "point:unique(id,stream_id)" UNIQUE (id, stream_id);
 
 
 --
@@ -325,7 +342,7 @@ CREATE OR REPLACE VIEW public.point_with_label_list AS
 --
 
 ALTER TABLE ONLY public.label
-    ADD CONSTRAINT "label:foreignKey(parent_id)" FOREIGN KEY (parent_id, user_id) REFERENCES public.label(id, user_id);
+    ADD CONSTRAINT "label:foreignKey(parent_id)" FOREIGN KEY (parent_id, user_id) REFERENCES public.label(id, user_id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -333,7 +350,7 @@ ALTER TABLE ONLY public.label
 --
 
 ALTER TABLE ONLY public.label
-    ADD CONSTRAINT "label:foreignKey(stream_id)" FOREIGN KEY (stream_id, user_id) REFERENCES public.stream(id, user_id);
+    ADD CONSTRAINT "label:foreignKey(stream_id)" FOREIGN KEY (stream_id, user_id) REFERENCES public.stream(id, user_id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -341,7 +358,7 @@ ALTER TABLE ONLY public.label
 --
 
 ALTER TABLE ONLY public.label
-    ADD CONSTRAINT "label:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ADD CONSTRAINT "label:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -349,7 +366,7 @@ ALTER TABLE ONLY public.label
 --
 
 ALTER TABLE ONLY public.point
-    ADD CONSTRAINT "point:foreignKey(stream_id)" FOREIGN KEY (stream_id, user_id) REFERENCES public.stream(id, user_id);
+    ADD CONSTRAINT "point:foreignKey(stream_id)" FOREIGN KEY (stream_id, user_id) REFERENCES public.stream(id, user_id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -357,7 +374,7 @@ ALTER TABLE ONLY public.point
 --
 
 ALTER TABLE ONLY public.point
-    ADD CONSTRAINT "point:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ADD CONSTRAINT "point:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -365,7 +382,7 @@ ALTER TABLE ONLY public.point
 --
 
 ALTER TABLE ONLY public.point_label
-    ADD CONSTRAINT "point_label:foreignKey(label_id)" FOREIGN KEY (label_id) REFERENCES public.label(id);
+    ADD CONSTRAINT "point_label:foreignKey(label_id)" FOREIGN KEY (label_id, stream_id) REFERENCES public.label(id, stream_id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -373,7 +390,15 @@ ALTER TABLE ONLY public.point_label
 --
 
 ALTER TABLE ONLY public.point_label
-    ADD CONSTRAINT "point_label:foreignKey(point_id)" FOREIGN KEY (point_id) REFERENCES public.point(id);
+    ADD CONSTRAINT "point_label:foreignKey(point_id)" FOREIGN KEY (point_id, stream_id) REFERENCES public.point(id, stream_id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+
+--
+-- Name: point_label point_label:foreignKey(stream_id); Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.point_label
+    ADD CONSTRAINT "point_label:foreignKey(stream_id)" FOREIGN KEY (stream_id) REFERENCES public.stream(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -381,7 +406,7 @@ ALTER TABLE ONLY public.point_label
 --
 
 ALTER TABLE ONLY public.replicache_client
-    ADD CONSTRAINT "replicache_client:foreignKey(replicache_client_group_id)" FOREIGN KEY (replicache_client_group_id) REFERENCES public.replicache_client_group(id);
+    ADD CONSTRAINT "replicache_client:foreignKey(replicache_client_group_id)" FOREIGN KEY (replicache_client_group_id) REFERENCES public.replicache_client_group(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -389,7 +414,7 @@ ALTER TABLE ONLY public.replicache_client
 --
 
 ALTER TABLE ONLY public.replicache_client_group
-    ADD CONSTRAINT "replicache_client_group:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ADD CONSTRAINT "replicache_client_group:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -397,7 +422,7 @@ ALTER TABLE ONLY public.replicache_client_group
 --
 
 ALTER TABLE ONLY public.stream
-    ADD CONSTRAINT "stream:foreignKey(parent_id)" FOREIGN KEY (parent_id, user_id) REFERENCES public.stream(id, user_id);
+    ADD CONSTRAINT "stream:foreignKey(parent_id)" FOREIGN KEY (parent_id, user_id) REFERENCES public.stream(id, user_id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -405,7 +430,7 @@ ALTER TABLE ONLY public.stream
 --
 
 ALTER TABLE ONLY public.stream
-    ADD CONSTRAINT "stream:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ADD CONSTRAINT "stream:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -413,7 +438,7 @@ ALTER TABLE ONLY public.stream
 --
 
 ALTER TABLE ONLY public.user_session
-    ADD CONSTRAINT "user_session:foreignKey(user_id,user)" FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ADD CONSTRAINT "user_session:foreignKey(user_id,user)" FOREIGN KEY (user_id) REFERENCES public."user"(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "replicache": "15.3.0",
     "resend": "6.8.0",
     "signia": "0.1.5",
-    "svelte-awesome-color-picker": "4.1.0",
+    "svelte-awesome-color-picker": "4.1.1",
     "websocket-ts": "2.2.1",
     "ws": "8.19.0",
-    "zod": "4.3.5"
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
     "@roughapp/replimock": "15.2.0",
     "@stayradiated/error-boundary": "4.3.0",
-    "@sveltejs/adapter-node": "5.5.0",
+    "@sveltejs/adapter-node": "5.5.1",
     "@sveltejs/kit": "2.50.0",
     "@sveltejs/vite-plugin-svelte": "6.2.4",
     "@types/node": "25.0.10",
@@ -53,13 +53,13 @@
     "knip": "5.82.1",
     "kysely": "0.28.10",
     "svelte": "5.48.0",
-    "svelte-check": "4.3.4",
+    "svelte-check": "4.3.5",
     "test-fixture-factory": "2.1.0",
     "type-fest": "5.4.1",
     "typescript": "5.9.3",
     "typescript-eslint": "8.53.1",
-    "vite": "7.3.0",
-    "vitest": "4.0.17"
+    "vite": "7.3.1",
+    "vitest": "4.0.18"
   },
   "knip": {
     "vite": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: 0.1.5
         version: 0.1.5
       svelte-awesome-color-picker:
-        specifier: 4.1.0
-        version: 4.1.0(svelte@5.48.0)
+        specifier: 4.1.1
+        version: 4.1.1(svelte@5.48.0)
       websocket-ts:
         specifier: 2.2.1
         version: 2.2.1
@@ -83,8 +83,8 @@ importers:
         specifier: 8.19.0
         version: 8.19.0
       zod:
-        specifier: 4.3.5
-        version: 4.3.5
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.11
@@ -96,14 +96,14 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       '@sveltejs/adapter-node':
-        specifier: 5.5.0
-        version: 5.5.0(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))
+        specifier: 5.5.1
+        version: 5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))
       '@sveltejs/kit':
         specifier: 2.50.0
-        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
+        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: 6.2.4
-        version: 6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
+        version: 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       '@types/node':
         specifier: 25.0.10
         version: 25.0.10
@@ -141,8 +141,8 @@ importers:
         specifier: 5.48.0
         version: 5.48.0
       svelte-check:
-        specifier: 4.3.4
-        version: 4.3.4(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3)
+        specifier: 4.3.5
+        version: 4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3)
       test-fixture-factory:
         specifier: 2.1.0
         version: 2.1.0
@@ -156,11 +156,11 @@ importers:
         specifier: 8.53.1
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
-        specifier: 7.3.0
-        version: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
+        specifier: 7.3.1
+        version: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
       vitest:
-        specifier: 4.0.17
-        version: 4.0.17(@types/node@25.0.10)(jiti@2.6.1)
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@25.0.10)(jiti@2.6.1)
 
 packages:
 
@@ -779,141 +779,141 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.55.3':
-    resolution: {integrity: sha512-qyX8+93kK/7R5BEXPC2PjUt0+fS/VO2BVHjEHyIEWiYn88rcRBHmdLgoJjktBltgAf+NY7RfCGB1SoyKS/p9kg==}
+  '@rollup/rollup-android-arm-eabi@4.56.0':
+    resolution: {integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.55.3':
-    resolution: {integrity: sha512-6sHrL42bjt5dHQzJ12Q4vMKfN+kUnZ0atHHnv4V0Wd9JMTk7FDzSY35+7qbz3ypQYMBPANbpGK7JpnWNnhGt8g==}
+  '@rollup/rollup-android-arm64@4.56.0':
+    resolution: {integrity: sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.55.3':
-    resolution: {integrity: sha512-1ht2SpGIjEl2igJ9AbNpPIKzb1B5goXOcmtD0RFxnwNuMxqkR6AUaaErZz+4o+FKmzxcSNBOLrzsICZVNYa1Rw==}
+  '@rollup/rollup-darwin-arm64@4.56.0':
+    resolution: {integrity: sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.55.3':
-    resolution: {integrity: sha512-FYZ4iVunXxtT+CZqQoPVwPhH7549e/Gy7PIRRtq4t5f/vt54pX6eG9ebttRH6QSH7r/zxAFA4EZGlQ0h0FvXiA==}
+  '@rollup/rollup-darwin-x64@4.56.0':
+    resolution: {integrity: sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.55.3':
-    resolution: {integrity: sha512-M/mwDCJ4wLsIgyxv2Lj7Len+UMHd4zAXu4GQ2UaCdksStglWhP61U3uowkaYBQBhVoNpwx5Hputo8eSqM7K82Q==}
+  '@rollup/rollup-freebsd-arm64@4.56.0':
+    resolution: {integrity: sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.55.3':
-    resolution: {integrity: sha512-5jZT2c7jBCrMegKYTYTpni8mg8y3uY8gzeq2ndFOANwNuC/xJbVAoGKR9LhMDA0H3nIhvaqUoBEuJoICBudFrA==}
+  '@rollup/rollup-freebsd-x64@4.56.0':
+    resolution: {integrity: sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
-    resolution: {integrity: sha512-YeGUhkN1oA+iSPzzhEjVPS29YbViOr8s4lSsFaZKLHswgqP911xx25fPOyE9+khmN6W4VeM0aevbDp4kkEoHiA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
+    resolution: {integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
-    resolution: {integrity: sha512-eo0iOIOvcAlWB3Z3eh8pVM8hZ0oVkK3AjEM9nSrkSug2l15qHzF3TOwT0747omI6+CJJvl7drwZepT+re6Fy/w==}
+  '@rollup/rollup-linux-arm-musleabihf@4.56.0':
+    resolution: {integrity: sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.3':
-    resolution: {integrity: sha512-DJay3ep76bKUDImmn//W5SvpjRN5LmK/ntWyeJs/dcnwiiHESd3N4uteK9FDLf0S0W8E6Y0sVRXpOCoQclQqNg==}
+  '@rollup/rollup-linux-arm64-gnu@4.56.0':
+    resolution: {integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.55.3':
-    resolution: {integrity: sha512-BKKWQkY2WgJ5MC/ayvIJTHjy0JUGb5efaHCUiG/39sSUvAYRBaO3+/EK0AZT1RF3pSj86O24GLLik9mAYu0IJg==}
+  '@rollup/rollup-linux-arm64-musl@4.56.0':
+    resolution: {integrity: sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.3':
-    resolution: {integrity: sha512-Q9nVlWtKAG7ISW80OiZGxTr6rYtyDSkauHUtvkQI6TNOJjFvpj4gcH+KaJihqYInnAzEEUetPQubRwHef4exVg==}
+  '@rollup/rollup-linux-loong64-gnu@4.56.0':
+    resolution: {integrity: sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.55.3':
-    resolution: {integrity: sha512-2H5LmhzrpC4fFRNwknzmmTvvyJPHwESoJgyReXeFoYYuIDfBhP29TEXOkCJE/KxHi27mj7wDUClNq78ue3QEBQ==}
+  '@rollup/rollup-linux-loong64-musl@4.56.0':
+    resolution: {integrity: sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
-    resolution: {integrity: sha512-9S542V0ie9LCTznPYlvaeySwBeIEa7rDBgLHKZ5S9DBgcqdJYburabm8TqiqG6mrdTzfV5uttQRHcbKff9lWtA==}
+  '@rollup/rollup-linux-ppc64-gnu@4.56.0':
+    resolution: {integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.3':
-    resolution: {integrity: sha512-ukxw+YH3XXpcezLgbJeasgxyTbdpnNAkrIlFGDl7t+pgCxZ89/6n1a+MxlY7CegU+nDgrgdqDelPRNQ/47zs0g==}
+  '@rollup/rollup-linux-ppc64-musl@4.56.0':
+    resolution: {integrity: sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
-    resolution: {integrity: sha512-Iauw9UsTTvlF++FhghFJjqYxyXdggXsOqGpFBylaRopVpcbfyIIsNvkf9oGwfgIcf57z3m8+/oSYTo6HutBFNw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.56.0':
+    resolution: {integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.3':
-    resolution: {integrity: sha512-3OqKAHSEQXKdq9mQ4eajqUgNIK27VZPW3I26EP8miIzuKzCJ3aW3oEn2pzF+4/Hj/Moc0YDsOtBgT5bZ56/vcA==}
+  '@rollup/rollup-linux-riscv64-musl@4.56.0':
+    resolution: {integrity: sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.3':
-    resolution: {integrity: sha512-0CM8dSVzVIaqMcXIFej8zZrSFLnGrAE8qlNbbHfTw1EEPnFTg1U1ekI0JdzjPyzSfUsHWtodilQQG/RA55berA==}
+  '@rollup/rollup-linux-s390x-gnu@4.56.0':
+    resolution: {integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.55.3':
-    resolution: {integrity: sha512-+fgJE12FZMIgBaKIAGd45rxf+5ftcycANJRWk8Vz0NnMTM5rADPGuRFTYar+Mqs560xuART7XsX2lSACa1iOmQ==}
+  '@rollup/rollup-linux-x64-gnu@4.56.0':
+    resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.55.3':
-    resolution: {integrity: sha512-tMD7NnbAolWPzQlJQJjVFh/fNH3K/KnA7K8gv2dJWCwwnaK6DFCYST1QXYWfu5V0cDwarWC8Sf/cfMHniNq21A==}
+  '@rollup/rollup-linux-x64-musl@4.56.0':
+    resolution: {integrity: sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.55.3':
-    resolution: {integrity: sha512-u5KsqxOxjEeIbn7bUK1MPM34jrnPwjeqgyin4/N6e/KzXKfpE9Mi0nCxcQjaM9lLmPcHmn/xx1yOjgTMtu1jWQ==}
+  '@rollup/rollup-openbsd-x64@4.56.0':
+    resolution: {integrity: sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.55.3':
-    resolution: {integrity: sha512-vo54aXwjpTtsAnb3ca7Yxs9t2INZg7QdXN/7yaoG7nPGbOBXYXQY41Km+S1Ov26vzOAzLcAjmMdjyEqS1JkVhw==}
+  '@rollup/rollup-openharmony-arm64@4.56.0':
+    resolution: {integrity: sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.3':
-    resolution: {integrity: sha512-HI+PIVZ+m+9AgpnY3pt6rinUdRYrGHvmVdsNQ4odNqQ/eRF78DVpMR7mOq7nW06QxpczibwBmeQzB68wJ+4W4A==}
+  '@rollup/rollup-win32-arm64-msvc@4.56.0':
+    resolution: {integrity: sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.3':
-    resolution: {integrity: sha512-vRByotbdMo3Wdi+8oC2nVxtc3RkkFKrGaok+a62AT8lz/YBuQjaVYAS5Zcs3tPzW43Vsf9J0wehJbUY5xRSekA==}
+  '@rollup/rollup-win32-ia32-msvc@4.56.0':
+    resolution: {integrity: sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.55.3':
-    resolution: {integrity: sha512-POZHq7UeuzMJljC5NjKi8vKMFN6/5EOqcX1yGntNLp7rUTpBAXQ1hW8kWPFxYLv07QMcNM75xqVLGPWQq6TKFA==}
+  '@rollup/rollup-win32-x64-gnu@4.56.0':
+    resolution: {integrity: sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.55.3':
-    resolution: {integrity: sha512-aPFONczE4fUFKNXszdvnd2GqKEYQdV5oEsIbKPujJmWlCI9zEsv1Otig8RKK+X9bed9gFUN6LAeN4ZcNuu4zjg==}
+  '@rollup/rollup-win32-x64-msvc@4.56.0':
+    resolution: {integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==}
     cpu: [x64]
     os: [win32]
 
@@ -946,8 +946,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/adapter-node@5.5.0':
-    resolution: {integrity: sha512-xHzWyo2vRYqR/DyyFboIOVplz411RAyZvt0/UVPebRIhg3PGXty09mjiRt0nPj7zL0oPxqeCTu4RmHdsFkP/7w==}
+  '@sveltejs/adapter-node@5.5.1':
+    resolution: {integrity: sha512-VpZdPNRPQuZRtgfAMETPWWKpZx9JwXmUUsgz/+eSpw/Oh7+2O1uZHlsQTuyfxydJHPrRzjfu/ItcJjY4oscCiQ==}
     peerDependencies:
       '@sveltejs/kit': ^2.4.0
 
@@ -1082,11 +1082,11 @@ packages:
     resolution: {integrity: sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/expect@4.0.17':
-    resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
-  '@vitest/mocker@4.0.17':
-    resolution: {integrity: sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==}
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -1096,20 +1096,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.17':
-    resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
-  '@vitest/runner@4.0.17':
-    resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
-  '@vitest/snapshot@4.0.17':
-    resolution: {integrity: sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==}
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
-  '@vitest/spy@4.0.17':
-    resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
 
-  '@vitest/utils@4.0.17':
-    resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -2109,8 +2109,8 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rollup@4.55.3:
-    resolution: {integrity: sha512-y9yUpfQvetAjiDLtNMf1hL9NXchIJgWt6zIKeoB+tCd3npX08Eqfzg60V9DhIGVMtQ0AlMkFw5xa+AQ37zxnAA==}
+  rollup@4.56.0:
+    resolution: {integrity: sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2214,8 +2214,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte-awesome-color-picker@4.1.0:
-    resolution: {integrity: sha512-afiSB3eTBlqu96f4+rjBvqG3eCaLwuneNYHe587Wr4Ien6yQWeztGZunPT0FmiI7wFFBVNUlJQLYutII8LfQUg==}
+  svelte-awesome-color-picker@4.1.1:
+    resolution: {integrity: sha512-k4APFGBFN8EpvUS0UJfdlqj8xDekMbqGBwnDYBK1QCY8kcTXSO8c7SitEk70MkiYOIByOgXlHcjaipy6H7dpAw==}
+    engines: {node: '>=24'}
     peerDependencies:
       svelte: ^5.0.0
 
@@ -2224,8 +2225,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
 
-  svelte-check@4.3.4:
-    resolution: {integrity: sha512-DVWvxhBrDsd+0hHWKfjP99lsSXASeOhHJYyuKOFYJcP7ThfSCKgjVarE8XfuMWpS5JV3AlDf+iK1YGGo2TACdw==}
+  svelte-check@4.3.5:
+    resolution: {integrity: sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
@@ -2407,8 +2408,8 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
-  vite@7.3.0:
-    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2455,18 +2456,18 @@ packages:
       vite:
         optional: true
 
-  vitest@4.0.17:
-    resolution: {integrity: sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==}
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.17
-      '@vitest/browser-preview': 4.0.17
-      '@vitest/browser-webdriverio': 4.0.17
-      '@vitest/ui': 4.0.17
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2563,8 +2564,8 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
-  zod@4.3.5:
-    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -2988,9 +2989,9 @@ snapshots:
 
   '@rocicorp/resolver@1.0.2': {}
 
-  '@rollup/plugin-commonjs@28.0.9(rollup@4.55.3)':
+  '@rollup/plugin-commonjs@28.0.9(rollup@4.56.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2998,105 +2999,105 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/plugin-json@6.1.0(rollup@4.55.3)':
+  '@rollup/plugin-json@6.1.0(rollup@4.56.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.55.3)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.56.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/pluginutils@5.3.0(rollup@4.55.3)':
+  '@rollup/pluginutils@5.3.0(rollup@4.56.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.55.3
+      rollup: 4.56.0
 
-  '@rollup/rollup-android-arm-eabi@4.55.3':
+  '@rollup/rollup-android-arm-eabi@4.56.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.55.3':
+  '@rollup/rollup-android-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.55.3':
+  '@rollup/rollup-darwin-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.55.3':
+  '@rollup/rollup-darwin-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.55.3':
+  '@rollup/rollup-freebsd-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.55.3':
+  '@rollup/rollup-freebsd-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
+  '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
+  '@rollup/rollup-linux-arm-musleabihf@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.3':
+  '@rollup/rollup-linux-arm64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.55.3':
+  '@rollup/rollup-linux-arm64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.3':
+  '@rollup/rollup-linux-loong64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.55.3':
+  '@rollup/rollup-linux-loong64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
+  '@rollup/rollup-linux-ppc64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.3':
+  '@rollup/rollup-linux-ppc64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
+  '@rollup/rollup-linux-riscv64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.3':
+  '@rollup/rollup-linux-riscv64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.3':
+  '@rollup/rollup-linux-s390x-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.55.3':
+  '@rollup/rollup-linux-x64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.55.3':
+  '@rollup/rollup-linux-x64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.55.3':
+  '@rollup/rollup-openbsd-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.55.3':
+  '@rollup/rollup-openharmony-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.3':
+  '@rollup/rollup-win32-arm64-msvc@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.3':
+  '@rollup/rollup-win32-ia32-msvc@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.55.3':
+  '@rollup/rollup-win32-x64-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.55.3':
+  '@rollup/rollup-win32-x64-msvc@4.56.0':
     optional: true
 
   '@roughapp/replimock@15.2.0(@electric-sql/pglite@0.3.15)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)':
@@ -3146,19 +3147,19 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-node@5.5.0(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))':
+  '@sveltejs/adapter-node@5.5.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))':
     dependencies:
-      '@rollup/plugin-commonjs': 28.0.9(rollup@4.55.3)
-      '@rollup/plugin-json': 6.1.0(rollup@4.55.3)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.55.3)
-      '@sveltejs/kit': 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
-      rollup: 4.55.3
+      '@rollup/plugin-commonjs': 28.0.9(rollup@4.56.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.56.0)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.56.0)
+      '@sveltejs/kit': 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      rollup: 4.56.0
 
-  '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
+  '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -3171,26 +3172,26 @@ snapshots:
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.48.0
-      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       obug: 2.1.1
       svelte: 5.48.0
-      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)))(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.48.0
-      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
-      vitefu: 1.1.1(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
+      vitefu: 1.1.1(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
 
   '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.48.0)':
     dependencies:
@@ -3327,43 +3328,43 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/expect@4.0.17':
+  '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.17
-      '@vitest/utils': 4.0.17
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.17(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))':
     dependencies:
-      '@vitest/spy': 4.0.17
+      '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
 
-  '@vitest/pretty-format@4.0.17':
+  '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.17':
+  '@vitest/runner@4.0.18':
     dependencies:
-      '@vitest/utils': 4.0.17
+      '@vitest/utils': 4.0.18
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.17':
+  '@vitest/snapshot@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 4.0.17
+      '@vitest/pretty-format': 4.0.18
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.17': {}
+  '@vitest/spy@4.0.18': {}
 
-  '@vitest/utils@4.0.17':
+  '@vitest/utils@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 4.0.17
+      '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
   abbrev@2.0.0: {}
@@ -4028,7 +4029,7 @@ snapshots:
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
       typescript: 5.9.3
-      zod: 4.3.5
+      zod: 4.3.6
 
   known-css-properties@0.37.0: {}
 
@@ -4350,35 +4351,35 @@ snapshots:
       glob: 13.0.0
       package-json-from-dist: 1.0.1
 
-  rollup@4.55.3:
+  rollup@4.56.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.55.3
-      '@rollup/rollup-android-arm64': 4.55.3
-      '@rollup/rollup-darwin-arm64': 4.55.3
-      '@rollup/rollup-darwin-x64': 4.55.3
-      '@rollup/rollup-freebsd-arm64': 4.55.3
-      '@rollup/rollup-freebsd-x64': 4.55.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.55.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.55.3
-      '@rollup/rollup-linux-arm64-gnu': 4.55.3
-      '@rollup/rollup-linux-arm64-musl': 4.55.3
-      '@rollup/rollup-linux-loong64-gnu': 4.55.3
-      '@rollup/rollup-linux-loong64-musl': 4.55.3
-      '@rollup/rollup-linux-ppc64-gnu': 4.55.3
-      '@rollup/rollup-linux-ppc64-musl': 4.55.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.55.3
-      '@rollup/rollup-linux-riscv64-musl': 4.55.3
-      '@rollup/rollup-linux-s390x-gnu': 4.55.3
-      '@rollup/rollup-linux-x64-gnu': 4.55.3
-      '@rollup/rollup-linux-x64-musl': 4.55.3
-      '@rollup/rollup-openbsd-x64': 4.55.3
-      '@rollup/rollup-openharmony-arm64': 4.55.3
-      '@rollup/rollup-win32-arm64-msvc': 4.55.3
-      '@rollup/rollup-win32-ia32-msvc': 4.55.3
-      '@rollup/rollup-win32-x64-gnu': 4.55.3
-      '@rollup/rollup-win32-x64-msvc': 4.55.3
+      '@rollup/rollup-android-arm-eabi': 4.56.0
+      '@rollup/rollup-android-arm64': 4.56.0
+      '@rollup/rollup-darwin-arm64': 4.56.0
+      '@rollup/rollup-darwin-x64': 4.56.0
+      '@rollup/rollup-freebsd-arm64': 4.56.0
+      '@rollup/rollup-freebsd-x64': 4.56.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.56.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.56.0
+      '@rollup/rollup-linux-arm64-gnu': 4.56.0
+      '@rollup/rollup-linux-arm64-musl': 4.56.0
+      '@rollup/rollup-linux-loong64-gnu': 4.56.0
+      '@rollup/rollup-linux-loong64-musl': 4.56.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.56.0
+      '@rollup/rollup-linux-ppc64-musl': 4.56.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.56.0
+      '@rollup/rollup-linux-riscv64-musl': 4.56.0
+      '@rollup/rollup-linux-s390x-gnu': 4.56.0
+      '@rollup/rollup-linux-x64-gnu': 4.56.0
+      '@rollup/rollup-linux-x64-musl': 4.56.0
+      '@rollup/rollup-openbsd-x64': 4.56.0
+      '@rollup/rollup-openharmony-arm64': 4.56.0
+      '@rollup/rollup-win32-arm64-msvc': 4.56.0
+      '@rollup/rollup-win32-ia32-msvc': 4.56.0
+      '@rollup/rollup-win32-x64-gnu': 4.56.0
+      '@rollup/rollup-win32-x64-msvc': 4.56.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -4466,7 +4467,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-awesome-color-picker@4.1.0(svelte@5.48.0):
+  svelte-awesome-color-picker@4.1.1(svelte@5.48.0):
     dependencies:
       colord: 2.9.3
       svelte: 5.48.0
@@ -4476,7 +4477,7 @@ snapshots:
     dependencies:
       svelte: 5.48.0
 
-  svelte-check@4.3.4(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3):
+  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
@@ -4595,32 +4596,32 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1):
+  vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.55.3
+      rollup: 4.56.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.0.10
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitefu@1.1.1(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1)):
+  vitefu@1.1.1(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)):
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
 
-  vitest@4.0.17(@types/node@25.0.10)(jiti@2.6.1):
+  vitest@4.0.18(@types/node@25.0.10)(jiti@2.6.1):
     dependencies:
-      '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@7.3.0(@types/node@25.0.10)(jiti@2.6.1))
-      '@vitest/pretty-format': 4.0.17
-      '@vitest/runner': 4.0.17
-      '@vitest/snapshot': 4.0.17
-      '@vitest/spy': 4.0.17
-      '@vitest/utils': 4.0.17
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -4632,7 +4633,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@25.0.10)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.10
@@ -4715,4 +4716,4 @@ snapshots:
 
   zimmerframe@1.1.4: {}
 
-  zod@4.3.5: {}
+  zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,3 @@ minimumReleaseAge: 1440
 
 onlyBuiltDependencies:
   - esbuild
-
-trustPolicy: no-downgrade

--- a/scripts/db/snapshot-schema.ts
+++ b/scripts/db/snapshot-schema.ts
@@ -256,7 +256,7 @@ async function main() {
     'pg_dump',
     DATABASE_URL,
     '--exclude-schema=graphile_migrate',
-    '--exclude-schema=graphile_worker',
+    '--exclude-schema=pgboss',
     '--schema-only',
     '--no-owner',
     '--format=p',

--- a/scripts/vite/dev
+++ b/scripts/vite/dev
@@ -63,7 +63,7 @@ start_server() {
     fi
 
     # Start vite in the background
-    nohup ./node_modules/.bin/vite --host 0.0.0.0 --open --strictPort --port "$VITE_PORT" > "$LOG_FILE" 2>&1 &
+    FORCE_COLOR=1 nohup ./node_modules/.bin/vite --host 0.0.0.0 --open --strictPort --port "$VITE_PORT" > "$LOG_FILE" 2>&1 &
     PID=$!
 
     # Save PID

--- a/src/lib/__generated__/kanel/public/PointLabel.ts
+++ b/src/lib/__generated__/kanel/public/PointLabel.ts
@@ -1,5 +1,6 @@
 import { pointId, type PointId } from './Point';
 import { labelId, type LabelId } from './Label';
+import { streamId, type StreamId } from './Stream';
 import type { ColumnType, Selectable, Insertable, Updateable } from 'kysely';
 import { z } from 'zod';
 
@@ -16,6 +17,8 @@ export default interface PointLabelTable {
   createdAt: ColumnType<number, number, number>;
 
   updatedAt: ColumnType<number, number, number>;
+
+  streamId: ColumnType<StreamId, StreamId, StreamId>;
 }
 
 export type PointLabel = Selectable<PointLabelTable>;
@@ -31,6 +34,7 @@ export const pointLabel = z.object({
   sortOrder: z.number(),
   createdAt: z.number(),
   updatedAt: z.number(),
+  streamId: streamId,
 });
 
 export const pointLabelInitializer = z.object({
@@ -40,6 +44,7 @@ export const pointLabelInitializer = z.object({
   sortOrder: z.number(),
   createdAt: z.number(),
   updatedAt: z.number(),
+  streamId: streamId,
 });
 
 export const pointLabelMutator = z.object({
@@ -49,4 +54,5 @@ export const pointLabelMutator = z.object({
   sortOrder: z.number().optional(),
   createdAt: z.number().optional(),
   updatedAt: z.number().optional(),
+  streamId: streamId.optional(),
 });

--- a/src/lib/mutator/index.server.ts
+++ b/src/lib/mutator/index.server.ts
@@ -1,8 +1,6 @@
 import type { ServerMutatorDefsImportMap } from './types.js'
 
 const mutators: ServerMutatorDefsImportMap = {
-  ping: import('./ping.server.js'),
-
   stream_create: import('./stream-create.server.js'),
   stream_setParent: import('./stream-set-parent.server.js'),
   stream_rename: import('./stream-rename.server.js'),
@@ -17,6 +15,8 @@ const mutators: ServerMutatorDefsImportMap = {
 
   point_create: import('./point-create.server.js'),
   point_slide: import('./point-slide.server.js'),
+
+  migrate_fixupLabelParents: import('./migrate-fixup-label-parents.server.js'),
 
   danger_deleteAllData: import('./danger-delete-all-data.server.js'),
 }

--- a/src/lib/mutator/index.ts
+++ b/src/lib/mutator/index.ts
@@ -1,8 +1,6 @@
 import type { LocalMutatorDefsImportMap } from './types.js'
 
 const mutators: LocalMutatorDefsImportMap = {
-  ping: import('./ping.js'),
-
   stream_create: import('./stream-create.js'),
   stream_setParent: import('./stream-set-parent.js'),
   stream_rename: import('./stream-rename.js'),
@@ -17,6 +15,8 @@ const mutators: LocalMutatorDefsImportMap = {
 
   point_create: import('./point-create.js'),
   point_slide: import('./point-slide.js'),
+
+  migrate_fixupLabelParents: import('./migrate-fixup-label-parents.js'),
 
   danger_deleteAllData: import('./danger-delete-all-data.js'),
 }

--- a/src/lib/mutator/migrate-fixup-label-parents.server.ts
+++ b/src/lib/mutator/migrate-fixup-label-parents.server.ts
@@ -1,0 +1,40 @@
+import type { ServerMutator } from './types.ts'
+
+import { getStreamList } from '#lib/server/db/stream/get-stream-list.js'
+
+import { fixupLabelParents } from '#lib/server/migrate/fixup-label-parents.js'
+
+const migrateFixuplabelParents: ServerMutator<
+  'migrate_fixupLabelParents'
+> = async (context, _options) => {
+  const { db, sessionUserId } = context
+
+  const streamList = await getStreamList({
+    db,
+    where: {
+      userId: sessionUserId,
+    },
+  })
+  if (streamList instanceof Error) {
+    return streamList
+  }
+
+  for (const stream of streamList) {
+    if (!stream.parentId) {
+      // ignore streams without a parent
+      continue
+    }
+    const result = await fixupLabelParents({
+      db,
+      streamId: stream.id,
+      parentStreamId: stream.parentId,
+      userId: sessionUserId,
+    })
+    if (result instanceof Error) {
+      console.error('fixupLabelParents error', result)
+      return result
+    }
+  }
+}
+
+export default migrateFixuplabelParents

--- a/src/lib/mutator/migrate-fixup-label-parents.ts
+++ b/src/lib/mutator/migrate-fixup-label-parents.ts
@@ -1,0 +1,9 @@
+import type { LocalMutator } from './types.ts'
+
+const migrateFixupLabelParents: LocalMutator<
+  'migrate_fixupLabelParents'
+> = async (_context, _options) => {
+  console.warn('migrateFixupLabelParents is not implemented locally')
+}
+
+export default migrateFixupLabelParents

--- a/src/lib/mutator/ping.server.ts
+++ b/src/lib/mutator/ping.server.ts
@@ -1,9 +1,0 @@
-import type { ServerMutator } from './types.ts'
-
-const ping: ServerMutator<'ping'> = async (_context, options) => {
-  const { message } = options
-
-  console.info('ping', message)
-}
-
-export default ping

--- a/src/lib/mutator/ping.ts
+++ b/src/lib/mutator/ping.ts
@@ -1,9 +1,0 @@
-import type { LocalMutator } from './types.ts'
-
-const ping: LocalMutator<'ping'> = async (_context, options) => {
-  const { message } = options
-
-  console.info('ping', message)
-}
-
-export default ping

--- a/src/lib/mutator/types.ts
+++ b/src/lib/mutator/types.ts
@@ -8,10 +8,6 @@ import type { Transaction } from '#lib/server/db/types.js'
  */
 
 type Mutators = {
-  ping: Mutator<{
-    message: string
-  }>
-
   label_create: Mutator<{
     labelId: LabelId
     streamId: StreamId
@@ -68,6 +64,8 @@ type Mutators = {
     pointId: PointId
     startedAt: number
   }>
+
+  migrate_fixupLabelParents: Mutator<Record<string, never>>
 
   danger_deleteAllData: Mutator<{
     userHasConfirmed: boolean

--- a/src/lib/server/db/label/get-label-list.ts
+++ b/src/lib/server/db/label/get-label-list.ts
@@ -1,6 +1,6 @@
 import { errorBoundary } from '@stayradiated/error-boundary'
 
-import type { LabelId, UserId } from '#lib/ids.js'
+import type { LabelId, StreamId, UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
 import type { Where } from '#lib/server/db/where.js'
 import type { Label } from '#lib/server/types.js'
@@ -12,6 +12,7 @@ type GetLabelListOptions = {
   where: Where<{
     userId: UserId
     labelId?: LabelId
+    streamId?: StreamId
   }>
 }
 
@@ -20,24 +21,17 @@ const getLabelList = async (
 ): Promise<Label[] | Error> => {
   const { db, where } = options
 
-  const labelList = await errorBoundary(() => {
+  return errorBoundary(() => {
     let query = db.selectFrom('label').selectAll()
 
     query = extendWhere(query)
       .string('id', where.labelId)
       .string('userId', where.userId)
+      .string('streamId', where.streamId)
       .done()
 
     return query.execute()
   })
-
-  if (labelList instanceof Error) {
-    return new Error('Failed to getPointList', {
-      cause: labelList,
-    })
-  }
-
-  return labelList
 }
 
 export { getLabelList }

--- a/src/lib/server/db/point/get-point-iterator.ts
+++ b/src/lib/server/db/point/get-point-iterator.ts
@@ -1,0 +1,48 @@
+import type { StreamId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { Where } from '#lib/server/db/where.js'
+import type { Point } from '#lib/server/types.js'
+
+import { getPointList } from './get-point-list.js'
+
+type GetPointIteratorOptions = {
+  db: KyselyDb
+  where: Where<{
+    userId: UserId
+    streamId: StreamId
+  }>
+  pageSize?: number
+}
+
+async function* getPointIterator(options: GetPointIteratorOptions) {
+  const { db, where, pageSize = 100 } = options
+
+  let pointer: Point | undefined
+
+  while (true) {
+    const pointList = await getPointList({
+      db,
+      where,
+      paginate: {
+        pointer,
+        limit: pageSize,
+      },
+    })
+    if (pointList instanceof Error) {
+      yield pointList
+      return
+    }
+    const hasMore = pointList.length === pageSize
+
+    for (const point of pointList) {
+      yield point
+    }
+
+    pointer = pointList.at(-1)
+    if (!hasMore) {
+      break
+    }
+  }
+}
+
+export { getPointIterator }

--- a/src/lib/server/db/point/get-point-list.ts
+++ b/src/lib/server/db/point/get-point-list.ts
@@ -1,6 +1,6 @@
 import { errorBoundary } from '@stayradiated/error-boundary'
 
-import type { PointId, UserId } from '#lib/ids.js'
+import type { PointId, StreamId, UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
 import type { Where } from '#lib/server/db/where.js'
 import type { PointWithLabelList } from '#lib/server/types.js'
@@ -12,32 +12,49 @@ type GetPointListOptions = {
   where: Where<{
     userId: UserId
     pointId?: PointId
+    streamId?: StreamId
   }>
+  paginate?: {
+    pointer: { startedAt: number; id: PointId } | undefined
+    limit: number
+  }
 }
 
 const getPointList = async (
   options: GetPointListOptions,
 ): Promise<PointWithLabelList[] | Error> => {
-  const { db, where } = options
+  const { db, where, paginate } = options
 
-  const pointList = await errorBoundary(() => {
+  return errorBoundary(() => {
     let query = db.selectFrom('pointWithLabelList').selectAll()
 
     query = extendWhere(query)
       .string('id', where.pointId)
       .string('userId', where.userId)
+      .string('streamId', where.streamId)
       .done()
+
+    if (paginate) {
+      query = query
+        .orderBy('startedAt', 'asc')
+        .orderBy('id', 'asc')
+        .limit(paginate.limit)
+
+      if (paginate.pointer) {
+        const pointerStartedAt = paginate.pointer.startedAt
+        const pointerId = paginate.pointer.id
+        query = query.where((eb) =>
+          eb(
+            eb.refTuple('startedAt', 'id'),
+            '>',
+            eb.tuple(pointerStartedAt, pointerId),
+          ),
+        )
+      }
+    }
 
     return query.execute()
   })
-
-  if (pointList instanceof Error) {
-    return new Error('Failed to getPointList', {
-      cause: pointList,
-    })
-  }
-
-  return pointList
 }
 
 export { getPointList }

--- a/src/lib/server/db/point/get-point.ts
+++ b/src/lib/server/db/point/get-point.ts
@@ -2,7 +2,7 @@ import { errorBoundary } from '@stayradiated/error-boundary'
 
 import type { PointId, UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
-import type { Point } from '#lib/server/types.js'
+import type { PointWithLabelList } from '#lib/server/types.js'
 
 type GetPoint = {
   db: KyselyDb
@@ -12,16 +12,18 @@ type GetPoint = {
   }
 }
 
-const getPoint = async (options: GetPoint): Promise<Point[] | Error> => {
+const getPoint = async (
+  options: GetPoint,
+): Promise<PointWithLabelList | undefined | Error> => {
   const { db, where } = options
 
   return errorBoundary(() =>
     db
-      .selectFrom('point')
+      .selectFrom('pointWithLabelList')
       .selectAll()
       .where('id', '=', where.pointId)
       .where('userId', '=', where.userId)
-      .execute(),
+      .executeTakeFirst(),
   )
 }
 

--- a/src/lib/server/db/point/update-point-label.ts
+++ b/src/lib/server/db/point/update-point-label.ts
@@ -1,43 +1,47 @@
 import { errorBoundary } from '@stayradiated/error-boundary'
 
-import type { LabelId, StreamId, UserId } from '#lib/ids.js'
+import type { LabelId, PointId, StreamId, UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
 import type { Where } from '#lib/server/db/where.js'
-import type { Label } from '#lib/server/types.js'
+import type { PointLabel } from '#lib/server/types.js'
 
 import { extendWhere } from '#lib/server/db/where.js'
 
-type UpdateLabelOptions = {
+type UpdatePointLabelOptions = {
   db: KyselyDb
   where: Where<{
     userId: UserId
+    pointId?: PointId
     labelId?: LabelId
     streamId?: StreamId
   }>
-  set: Partial<Pick<Label, 'streamId' | 'name' | 'parentId' | 'color' | 'icon'>>
+  set: Partial<
+    Pick<PointLabel, 'pointId' | 'labelId' | 'streamId' | 'sortOrder'>
+  >
   now?: number
 }
 
-const updateLabel = async (
-  options: UpdateLabelOptions,
-): Promise<Label[] | Error> => {
+const updatePointLabel = async (
+  options: UpdatePointLabelOptions,
+): Promise<PointLabel[] | Error> => {
   const { db, where, set, now = Date.now() } = options
 
   return errorBoundary(() => {
     let query = db
-      .updateTable('label')
+      .updateTable('pointLabel')
       .set({
-        name: set.name,
-        parentId: set.parentId,
-        color: set.color,
-        icon: set.icon,
+        pointId: set.pointId,
+        labelId: set.labelId,
+        streamId: set.streamId,
+        sortOrder: set.sortOrder,
         updatedAt: now,
       })
       .returningAll()
 
     query = extendWhere(query)
-      .string('id', where.labelId)
+      .string('pointId', where.pointId)
       .string('userId', where.userId)
+      .string('labelId', where.labelId)
       .string('streamId', where.streamId)
       .done()
 
@@ -45,4 +49,4 @@ const updateLabel = async (
   })
 }
 
-export { updateLabel }
+export { updatePointLabel }

--- a/src/lib/server/db/point/update-point.ts
+++ b/src/lib/server/db/point/update-point.ts
@@ -1,37 +1,45 @@
 import { errorBoundary } from '@stayradiated/error-boundary'
 
-import type { PointId, UserId } from '#lib/ids.js'
+import type { PointId, StreamId, UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
+import type { Where } from '#lib/server/db/where.js'
 import type { Point } from '#lib/server/types.js'
+
+import { extendWhere } from '#lib/server/db/where.js'
 
 type UpdatePointOptions = {
   db: KyselyDb
-  where: {
+  where: Where<{
     userId: UserId
-    pointId: PointId
-  }
+    pointId?: PointId
+    streamId?: StreamId
+  }>
   set: Partial<Pick<Point, 'startedAt' | 'description'>>
   now?: number
 }
 
 const updatePoint = async (
   options: UpdatePointOptions,
-): Promise<Point | Error> => {
-  const { db, set, now = Date.now() } = options
+): Promise<Point[] | Error> => {
+  const { db, where, set, now = Date.now() } = options
 
-  return errorBoundary(() =>
-    db
+  return errorBoundary(() => {
+    let query = db
       .updateTable('point')
       .set({
         startedAt: set.startedAt,
         description: set.description,
         updatedAt: now,
       })
-      .where('id', '=', options.where.pointId)
-      .where('userId', '=', options.where.userId)
       .returningAll()
-      .executeTakeFirstOrThrow(),
-  )
+
+    query = extendWhere(query)
+      .string('id', where.pointId)
+      .string('userId', where.userId)
+      .done()
+
+    return query.execute()
+  })
 }
 
 export { updatePoint }

--- a/src/lib/server/db/point/upsert-point.ts
+++ b/src/lib/server/db/point/upsert-point.ts
@@ -56,6 +56,7 @@ const upsertPoint = async (
       (labelId, index): PointLabel => ({
         pointId: point.id,
         labelId,
+        streamId: where.streamId,
         userId: where.userId,
         sortOrder: index,
         createdAt: now,

--- a/src/lib/server/db/where.ts
+++ b/src/lib/server/db/where.ts
@@ -40,6 +40,7 @@ type ExtractTypeFromStringReference<
 type Id<T extends string> =
   | T
   | { eq: T }
+  | { gt: T }
   | { in: ReadonlyArray<T> }
   | { notIn: ReadonlyArray<T> }
   | typeof ANY_ID
@@ -115,6 +116,9 @@ const whereString = (
     if ('eq' in value) {
       return query.where(column, '=', value.eq)
     }
+    if ('gt' in value) {
+      return query.where(column, '>', value.gt)
+    }
     if ('in' in value) {
       if (value.in.length === 0) {
         // special case: in([]) is always false
@@ -164,6 +168,11 @@ const whereEitherString = (
     if ('eq' in value) {
       return query.where((eb) =>
         eb.or([eb(columns[0], '=', value.eq), eb(columns[1], '=', value.eq)]),
+      )
+    }
+    if ('gt' in value) {
+      return query.where((eb) =>
+        eb.or([eb(columns[0], '>', value.gt), eb(columns[1], '>', value.gt)]),
       )
     }
     if ('in' in value) {

--- a/src/lib/server/migrate/fixup-label-parents.ts
+++ b/src/lib/server/migrate/fixup-label-parents.ts
@@ -1,0 +1,228 @@
+import type { LabelId, PointId, StreamId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { Label, PointWithLabelList } from '#lib/server/types.js'
+
+import { getLabelList } from '#lib/server/db/label/get-label-list.js'
+import { insertLabel } from '#lib/server/db/label/insert-label.js'
+import { updateLabel } from '#lib/server/db/label/update-label.js'
+import { getPointIterator } from '#lib/server/db/point/get-point-iterator.js'
+import { updatePointLabel } from '#lib/server/db/point/update-point-label.js'
+
+import { genId } from '#lib/utils/gen-id.js'
+import { withPeek } from '#lib/utils/peek.js'
+
+const PAGE_SIZE = 500
+
+type FixupLabelParentsOptions = {
+  db: KyselyDb
+  streamId: StreamId
+  parentStreamId: StreamId
+  userId: UserId
+}
+
+const fixupLabelParents = async (
+  options: FixupLabelParentsOptions,
+): Promise<void | Error> => {
+  const { db, streamId, parentStreamId, userId } = options
+
+  const streamLabelList = await getLabelList({
+    db,
+    where: {
+      userId,
+      streamId,
+    },
+  })
+  if (streamLabelList instanceof Error) {
+    return new Error('Failed to getLabelList', { cause: streamLabelList })
+  }
+  const streamLabelRecord = Object.fromEntries(
+    streamLabelList.map((label) => [label.id, label]),
+  )
+
+  type Mutation = Pick<Label, 'parentId'>
+  const mutationRecord: Record<LabelId, Mutation> = {}
+
+  const resolveLabel = (labelId: LabelId): Label | Error => {
+    const label = streamLabelRecord[labelId]
+    if (!label) {
+      return new Error(`Cannot resolve label ID "${labelId}".`)
+    }
+    const mutation = mutationRecord[labelId]
+    if (mutation) {
+      return { ...label, ...mutation }
+    }
+    return label
+  }
+
+  type SetLabelParentIdOptions = {
+    labelId: LabelId
+    parentLabelId: LabelId | null
+  }
+  const setLabelParentId = async (
+    options: SetLabelParentIdOptions,
+  ): Promise<void | Error> => {
+    const { labelId, parentLabelId } = options
+
+    const label = resolveLabel(labelId)
+    if (label instanceof Error) {
+      return label
+    }
+    if (mutationRecord[labelId]) {
+      return new Error(
+        `Label "${label.name}" already has a parentId. Skipping.`,
+      )
+    }
+    mutationRecord[labelId] = { parentId: parentLabelId ?? null }
+
+    const updatedLabel = await updateLabel({
+      db,
+      where: { labelId, userId },
+      set: { parentId: parentLabelId },
+    })
+    if (updatedLabel instanceof Error) {
+      return updatedLabel
+    }
+  }
+
+  type StreamIdAndName = `${StreamId}:${string}`
+  const labelCacheRecord: Record<StreamIdAndName, Label> = {}
+
+  type DuplicateLabelAndUpdatePointOptions = {
+    pointId: PointId
+    labelId: LabelId
+    parentLabelId: LabelId | null
+  }
+
+  const duplicateLabelAndUpdatePoint = async (
+    options: DuplicateLabelAndUpdatePointOptions,
+  ): Promise<void | Error> => {
+    const { pointId, labelId, parentLabelId } = options
+
+    const label = resolveLabel(labelId)
+    if (label instanceof Error) {
+      return label
+    }
+    const key: StreamIdAndName = `${parentStreamId}:${label.name}`
+    if (!labelCacheRecord[key]) {
+      const newLabel = await insertLabel({
+        db,
+        set: {
+          ...label,
+          id: genId(),
+          parentId: parentLabelId,
+        },
+      })
+      if (newLabel instanceof Error) {
+        return newLabel
+      }
+      labelCacheRecord[key] = newLabel
+    }
+    const nextLabel = labelCacheRecord[key]
+    if (!nextLabel) {
+      return new Error(`Failed to duplicate label "${label.name}".`)
+    }
+    const result = await updatePointLabel({
+      db,
+      where: { pointId, labelId, userId },
+      set: { labelId: nextLabel.id },
+    })
+    if (result instanceof Error) {
+      return result
+    }
+  }
+
+  /*
+   * for a given stream
+   * iterate through each point in that stream, chronologically
+   * iterate through each label of that point
+   * compare that label's parentId to the label of the active point in the parent stream
+   * if the label doesn't have a parentId, set it to the parent streams active point's label
+   * if the label already has a parentId, but it's different, duplicate the label and set the new label's parentId to the active point's label and then update the point to use this new label
+   */
+
+  const pointIterator = getPointIterator({
+    db,
+    where: { userId, streamId },
+    pageSize: PAGE_SIZE,
+  })
+
+  const parentStreamPointIterator = withPeek(
+    getPointIterator({
+      db,
+      where: { userId, streamId: parentStreamId },
+      pageSize: PAGE_SIZE,
+    }),
+  )
+
+  // holds the the current parent point
+  let parentPoint: PointWithLabelList | undefined
+
+  for await (const point of pointIterator) {
+    if (point instanceof Error) {
+      return point
+    }
+
+    // iterate through the parent stream until we find a point that matches the current point's label
+    while (true) {
+      const nextParentPoint = await parentStreamPointIterator.peek()
+      if (nextParentPoint instanceof Error) {
+        return nextParentPoint
+      }
+      if (!nextParentPoint) {
+        // we've reached the end of the parent stream
+        break
+      }
+      if (nextParentPoint.startedAt > point.startedAt) {
+        // the next parent point is in the future, so we stop here
+        break
+      }
+
+      // otherwise, the next parent point becomes our parent point
+      parentPoint = nextParentPoint
+
+      // important, let's move the iterator forward
+      // otherwise we'll keep looping and looping and looping
+      await parentStreamPointIterator.next()
+    }
+
+    if (!parentPoint) {
+      console.error(`No parent point found for point "${point.id}".`)
+      return
+    }
+    const parentLabelId = parentPoint.labelIdList.at(0) ?? null
+
+    for (const labelId of point.labelIdList) {
+      const label = resolveLabel(labelId)
+      if (label instanceof Error) {
+        return label
+      }
+
+      if (label.parentId === parentLabelId) {
+        // label already has the correct parentId, so we don't need to do anything
+        continue
+      }
+
+      if (!label.parentId) {
+        const result = await setLabelParentId({
+          labelId: label.id,
+          parentLabelId,
+        })
+        if (result instanceof Error) {
+          return result
+        }
+        continue
+      }
+
+      const result = await duplicateLabelAndUpdatePoint({
+        pointId: point.id,
+        labelId: label.id,
+        parentLabelId,
+      })
+      if (result instanceof Error) {
+        return result
+      }
+    }
+  }
+}
+
+export { fixupLabelParents }

--- a/src/lib/utils/peek.ts
+++ b/src/lib/utils/peek.ts
@@ -1,0 +1,39 @@
+type AsyncIterableWithPeek<TValue, TReturn, TNext> = AsyncIterator<
+  TValue,
+  TReturn,
+  TNext
+> & {
+  peek(): Promise<TValue | undefined>
+}
+
+const withPeek = <TValue, TReturn, TNext>(
+  iterable: AsyncIterator<TValue, TReturn, TNext>,
+): AsyncIterableWithPeek<TValue, TReturn, TNext> => {
+  let peekedValue: TValue | undefined
+
+  const peek = async (): Promise<TValue | undefined> => {
+    if (peekedValue) {
+      return peekedValue
+    }
+    const { value, done } = await iterable.next()
+    if (done) {
+      return undefined
+    }
+    peekedValue = value
+    return value
+  }
+
+  return {
+    peek,
+    async next() {
+      if (peekedValue) {
+        const nextValue = peekedValue
+        peekedValue = undefined
+        return { done: undefined, value: nextValue }
+      }
+      return iterable.next()
+    },
+  }
+}
+
+export { withPeek }

--- a/src/routes/(app)/api/internal/replicache/push/process-mutation.ts
+++ b/src/routes/(app)/api/internal/replicache/push/process-mutation.ts
@@ -96,27 +96,25 @@ const processMutation = async (
     }
   }
 
-  const [updatedReplicacheClient, updatedReplicacheClientGroup] =
-    await Promise.all([
-      upsertReplicacheClient({
-        db,
-        where: { replicacheClientId },
-        set: { replicacheClientGroupId, lastMutationId: nextMutationId },
-      }),
-      upsertReplicacheClientGroup({
-        db,
-        where: { replicacheClientGroupId },
-        set: {
-          userId: sessionUserId,
-          cvrVersion: replicacheClientGroup.cvrVersion,
-        },
-      }),
-    ])
-  if (updatedReplicacheClient instanceof Error) {
-    return updatedReplicacheClient
-  }
+  const updatedReplicacheClientGroup = await upsertReplicacheClientGroup({
+    db,
+    where: { replicacheClientGroupId },
+    set: {
+      userId: sessionUserId,
+      cvrVersion: replicacheClientGroup.cvrVersion,
+    },
+  })
   if (updatedReplicacheClientGroup instanceof Error) {
     return updatedReplicacheClientGroup
+  }
+
+  const updatedReplicacheClient = await upsertReplicacheClient({
+    db,
+    where: { replicacheClientId },
+    set: { replicacheClientGroupId, lastMutationId: nextMutationId },
+  })
+  if (updatedReplicacheClient instanceof Error) {
+    return updatedReplicacheClient
   }
 }
 

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -47,6 +47,10 @@ const handleDeleteAllData = async () => {
     userHasConfirmed: true,
   })
 }
+
+const handleAssignLabelParent = async () => {
+  await store.mutate.migrate_fixupLabelParents({})
+}
 </script>
 
 <main>
@@ -61,6 +65,12 @@ const handleDeleteAllData = async () => {
   <section>
     <h2>Streams</h2>
     <StreamManager {store} />
+  </section>
+
+  <section>
+    <h2>Assign Parent Labels</h2>
+    <p>Scan existing labels and associate them with the correct parent.</p>
+    <button onclick={handleAssignLabelParent}>Assign Label Parent</button>
   </section>
 
   <section>


### PR DESCRIPTION
## Summary
Add stream-scoped label support: introduce stream_id on point_label with new DB constraints and provide a server-side migration to fix label parent relationships across streams. Also bump several dev/runtime dependencies and small developer tooling updates.

## Changes
- Database
  - New migrations (migrations/committed/000004.sql, 000005.sql) and schema.sql updates to add stream_id to point_label, add UNIQUE(id, stream_id) on point and label, and create composite foreign keys to ensure points and labels belong to the same stream.
  - Foreign key behavior updated to ON UPDATE/DELETE RESTRICT across multiple tables.
- Server / migration tooling
  - New server mutator migrate_fixupLabelParents (server + local stub) and implementation fixupLabelParents that iterates points and labels, sets/duplicates labels as needed to maintain correct parent relationships across streams.
  - New DB helpers: get-point-iterator, update-point-label, and utilities (withPeek). Several existing DB functions (getPointList, getLabelList, updatePoint, updateLabel, upsertPoint) extended to accept streamId and pagination/Where improvements.
  - Generated types updated (PointLabel now includes streamId).
- UI / scripts / deps
  - Settings page adds a button to run the migration (Assign Parent Labels).
  - Minor script tweaks: vite dev now sets FORCE_COLOR, pg_dump excludes changed to pgboss in snapshot script.
  - Dependency bumps (package.json + pnpm-lock.yaml): svelte-awesome-color-picker, zod, @sveltejs/adapter-node, svelte-check, vite, vitest, rollup and related lock updates; removed trustPolicy from pnpm-workspace.yaml.

## Breaking changes / migrations / notes
- Run the new SQL migrations before deploying code that depends on the schema change. point_label.stream_id is NOT NULL and new UNIQUE/composite FKs are added — existing data must be migrated to satisfy them.
- DB helper signatures and return shapes changed in places (e.g., updateLabel/updatePoint/updatePointLabel now use a generic Where helper and return arrays of rows). If you call these helpers directly, check updated types/returns.
- The migration mutator can duplicate labels when necessary; review results and backups are recommended before running on production data.
- This PR contains substantial lockfile changes (pnpm), so CI installs may take longer the first time.

If you want, I can extract a short upgrade checklist for deploy/migration steps.