### PR TITLE
feat(meta): add meta_task tracking, DB migrations, and CVR persistence

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/migrations/committed/000006.sql
+++ b/migrations/committed/000006.sql
@@ -1,0 +1,16 @@
+--! Previous: sha1:54c93b8fa94f452d73ade53ac43855adbc0f8cf3
+--! Hash: sha1:9231255bee46b498e2569fca4349b0f3534a530f
+
+--
+-- track cvr schema version
+--
+
+-- idempotent reset
+ALTER TABLE replicache_client_view
+  DROP COLUMN IF EXISTS version;
+
+-- remove all exisitng cvr records
+DELETE FROM replicache_client_view;
+
+ALTER TABLE replicache_client_view
+  ADD COLUMN version TEXT NOT NULL;

--- a/migrations/committed/000007.sql
+++ b/migrations/committed/000007.sql
@@ -1,0 +1,32 @@
+--! Previous: sha1:9231255bee46b498e2569fca4349b0f3534a530f
+--! Hash: sha1:271334242019cc93e0d33944fb4e7da375fb9f81
+
+--
+-- create a new table for tracking async tasks
+--
+
+-- idempotent reset
+DROP TABLE IF EXISTS meta_task;
+
+CREATE TABLE meta_task (
+  id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  last_started_at BIGINT NOT NULL,
+  last_finished_at BIGINT,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL
+);
+
+ALTER TABLE meta_task
+  ADD CONSTRAINT "meta_task:primaryKey(id)"
+    PRIMARY KEY (id),
+  ADD CONSTRAINT "meta_task:unique(user_id,name)"
+    UNIQUE (user_id, name),
+  ADD CONSTRAINT "meta_task:foreignKey(user_id,user)"
+    FOREIGN KEY (user_id)
+    REFERENCES public.user (id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD CONSTRAINT "meta_task:check(last_finished_at)"
+    CHECK (last_finished_at IS NULL OR last_finished_at > last_started_at);

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -56,6 +56,23 @@ CREATE TABLE public.label (
 
 
 --
+-- Name: meta_task; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.meta_task (
+    id text NOT NULL,
+    user_id text NOT NULL,
+    name text NOT NULL,
+    status text NOT NULL,
+    last_started_at bigint NOT NULL,
+    last_finished_at bigint,
+    created_at bigint NOT NULL,
+    updated_at bigint NOT NULL,
+    CONSTRAINT "meta_task:check(last_finished_at)" CHECK (((last_finished_at IS NULL) OR (last_finished_at > last_started_at)))
+);
+
+
+--
 -- Name: point; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -134,7 +151,8 @@ CREATE TABLE public.replicache_client_group (
 CREATE TABLE public.replicache_client_view (
     id text NOT NULL,
     record jsonb NOT NULL,
-    created_at bigint NOT NULL
+    created_at bigint NOT NULL,
+    version text NOT NULL
 );
 
 
@@ -213,6 +231,22 @@ ALTER TABLE ONLY public.label
 
 ALTER TABLE ONLY public.label
     ADD CONSTRAINT "label:unique(id,user_id)" UNIQUE (id, user_id);
+
+
+--
+-- Name: meta_task meta_task:primaryKey(id); Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.meta_task
+    ADD CONSTRAINT "meta_task:primaryKey(id)" PRIMARY KEY (id);
+
+
+--
+-- Name: meta_task meta_task:unique(user_id,name); Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.meta_task
+    ADD CONSTRAINT "meta_task:unique(user_id,name)" UNIQUE (user_id, name);
 
 
 --
@@ -359,6 +393,14 @@ ALTER TABLE ONLY public.label
 
 ALTER TABLE ONLY public.label
     ADD CONSTRAINT "label:foreignKey(user_id)" FOREIGN KEY (user_id) REFERENCES public."user"(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+
+--
+-- Name: meta_task meta_task:foreignKey(user_id,user); Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.meta_task
+    ADD CONSTRAINT "meta_task:foreignKey(user_id,user)" FOREIGN KEY (user_id) REFERENCES public."user"(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "graphile-migrate": "1.4.1",
     "p-map": "7.0.4",
     "pg": "8.17.2",
-    "pg-boss": "12.5.4",
+    "pg-boss": "12.6.0",
     "replicache": "15.3.0",
     "resend": "6.8.0",
     "signia": "0.1.5",
@@ -35,7 +35,7 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.12",
+    "@biomejs/biome": "2.3.13",
     "@roughapp/replimock": "15.2.0",
     "@stayradiated/error-boundary": "4.3.0",
     "@sveltejs/adapter-node": "5.5.2",
@@ -57,7 +57,7 @@
     "test-fixture-factory": "2.1.0",
     "type-fest": "5.4.1",
     "typescript": "5.9.3",
-    "typescript-eslint": "8.53.1",
+    "typescript-eslint": "8.54.0",
     "vite": "7.3.1",
     "vitest": "4.0.18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: 8.17.2
         version: 8.17.2
       pg-boss:
-        specifier: 12.5.4
-        version: 12.5.4
+        specifier: 12.6.0
+        version: 12.6.0
       replicache:
         specifier: 15.3.0
         version: 15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9)
@@ -87,8 +87,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.12
-        version: 2.3.12
+        specifier: 2.3.13
+        version: 2.3.13
       '@roughapp/replimock':
         specifier: 15.2.0
         version: 15.2.0(@electric-sql/pglite@0.3.15)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)
@@ -153,8 +153,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: 8.53.1
-        version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 8.54.0
+        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 7.3.1
         version: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)
@@ -168,59 +168,59 @@ packages:
     resolution: {integrity: sha512-slP2blSd6A+xUBgGf+wW6adGd72ojBLxemU0jXQ0fXQcsZWYQ70wTLTJggs6+oxcAqN/bvYA3Ops8SqR2Imyaw==}
     engines: {node: '>= 16'}
 
-  '@biomejs/biome@2.3.12':
-    resolution: {integrity: sha512-AR7h4aSlAvXj7TAajW/V12BOw2EiS0AqZWV5dGozf4nlLoUF/ifvD0+YgKSskT0ylA6dY1A8AwgP8kZ6yaCQnA==}
+  '@biomejs/biome@2.3.13':
+    resolution: {integrity: sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.12':
-    resolution: {integrity: sha512-cO6fn+KiMBemva6EARDLQBxeyvLzgidaFRJi8G7OeRqz54kWK0E+uSjgFaiHlc3DZYoa0+1UFE8mDxozpc9ieg==}
+  '@biomejs/cli-darwin-arm64@2.3.13':
+    resolution: {integrity: sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.12':
-    resolution: {integrity: sha512-/fiF/qmudKwSdvmSrSe/gOTkW77mHHkH8Iy7YC2rmpLuk27kbaUOPa7kPiH5l+3lJzTUfU/t6x1OuIq/7SGtxg==}
+  '@biomejs/cli-darwin-x64@2.3.13':
+    resolution: {integrity: sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.12':
-    resolution: {integrity: sha512-aqkeSf7IH+wkzFpKeDVPSXy9uDjxtLpYA6yzkYsY+tVjwFFirSuajHDI3ul8en90XNs1NA0n8kgBrjwRi5JeyA==}
+  '@biomejs/cli-linux-arm64-musl@2.3.13':
+    resolution: {integrity: sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.3.12':
-    resolution: {integrity: sha512-nbOsuQROa3DLla5vvsTZg+T5WVPGi9/vYxETm9BOuLHBJN3oWQIg3MIkE2OfL18df1ZtNkqXkH6Yg9mdTPem7A==}
+  '@biomejs/cli-linux-arm64@2.3.13':
+    resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.3.12':
-    resolution: {integrity: sha512-kVGWtupRRsOjvw47YFkk5mLiAdpCPMWBo1jOwAzh+juDpUb2sWarIp+iq+CPL1Wt0LLZnYtP7hH5kD6fskcxmg==}
+  '@biomejs/cli-linux-x64-musl@2.3.13':
+    resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.3.12':
-    resolution: {integrity: sha512-CQtqrJ+qEEI8tgRSTjjzk6wJAwfH3wQlkIGsM5dlecfRZaoT+XCms/mf7G4kWNexrke6mnkRzNy6w8ebV177ow==}
+  '@biomejs/cli-linux-x64@2.3.13':
+    resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.3.12':
-    resolution: {integrity: sha512-Re4I7UnOoyE4kHMqpgtG6UvSBGBbbtvsOvBROgCCoH7EgANN6plSQhvo2W7OCITvTp7gD6oZOyZy72lUdXjqZg==}
+  '@biomejs/cli-win32-arm64@2.3.13':
+    resolution: {integrity: sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.12':
-    resolution: {integrity: sha512-qqGVWqNNek0KikwPZlOIoxtXgsNGsX+rgdEzgw82Re8nF02W+E2WokaQhpF5TdBh/D/RQ3TLppH+otp6ztN0lw==}
+  '@biomejs/cli-win32-x64@2.3.13':
+    resolution: {integrity: sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1023,63 +1023,63 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/eslint-plugin@8.53.1':
-    resolution: {integrity: sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==}
+  '@typescript-eslint/eslint-plugin@8.54.0':
+    resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.53.1
+      '@typescript-eslint/parser': ^8.54.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.53.1':
-    resolution: {integrity: sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.53.1':
-    resolution: {integrity: sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.53.1':
-    resolution: {integrity: sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.53.1':
-    resolution: {integrity: sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.53.1':
-    resolution: {integrity: sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==}
+  '@typescript-eslint/parser@8.54.0':
+    resolution: {integrity: sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.53.1':
-    resolution: {integrity: sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.53.1':
-    resolution: {integrity: sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==}
+  '@typescript-eslint/project-service@8.54.0':
+    resolution: {integrity: sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.53.1':
-    resolution: {integrity: sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==}
+  '@typescript-eslint/scope-manager@8.54.0':
+    resolution: {integrity: sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.54.0':
+    resolution: {integrity: sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.54.0':
+    resolution: {integrity: sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.53.1':
-    resolution: {integrity: sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==}
+  '@typescript-eslint/types@8.54.0':
+    resolution: {integrity: sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.54.0':
+    resolution: {integrity: sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.54.0':
+    resolution: {integrity: sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.54.0':
+    resolution: {integrity: sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@4.0.18':
@@ -1779,8 +1779,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.4:
-    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
+  lru-cache@11.2.5:
+    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
     engines: {node: 20 || >=22}
 
   luxon@3.7.2:
@@ -1920,8 +1920,8 @@ packages:
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
-  pg-boss@12.5.4:
-    resolution: {integrity: sha512-I52Gkpda6lLNZNDZVKN5sWYO2YKndI3bBwOGAHY7xC+UBYMHI3m2tWSmDGjuq/odf6zpGoFSKVUUukTEaBZocA==}
+  pg-boss@12.6.0:
+    resolution: {integrity: sha512-wrwfmBSZ88kNGjv3o8wofshAQxVBYJwp0ATkpr2/+C8VMc/6N1WhCazt+EXiVyox+4u5KyIIOqlTrAUSd3FItA==}
     engines: {node: '>=22.12.0'}
 
   pg-cloudflare@1.3.0:
@@ -2383,8 +2383,8 @@ packages:
     resolution: {integrity: sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ==}
     engines: {node: '>=20'}
 
-  typescript-eslint@8.53.1:
-    resolution: {integrity: sha512-gB+EVQfP5RDElh9ittfXlhZJdjSU4jUSTyE2+ia8CYyNvet4ElfaLlAIqDvQV9JPknKx0jQH1racTYe/4LaLSg==}
+  typescript-eslint@8.54.0:
+    resolution: {integrity: sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2571,39 +2571,39 @@ snapshots:
 
   '@badrap/valita@0.3.16': {}
 
-  '@biomejs/biome@2.3.12':
+  '@biomejs/biome@2.3.13':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.12
-      '@biomejs/cli-darwin-x64': 2.3.12
-      '@biomejs/cli-linux-arm64': 2.3.12
-      '@biomejs/cli-linux-arm64-musl': 2.3.12
-      '@biomejs/cli-linux-x64': 2.3.12
-      '@biomejs/cli-linux-x64-musl': 2.3.12
-      '@biomejs/cli-win32-arm64': 2.3.12
-      '@biomejs/cli-win32-x64': 2.3.12
+      '@biomejs/cli-darwin-arm64': 2.3.13
+      '@biomejs/cli-darwin-x64': 2.3.13
+      '@biomejs/cli-linux-arm64': 2.3.13
+      '@biomejs/cli-linux-arm64-musl': 2.3.13
+      '@biomejs/cli-linux-x64': 2.3.13
+      '@biomejs/cli-linux-x64-musl': 2.3.13
+      '@biomejs/cli-win32-arm64': 2.3.13
+      '@biomejs/cli-win32-x64': 2.3.13
 
-  '@biomejs/cli-darwin-arm64@2.3.12':
+  '@biomejs/cli-darwin-arm64@2.3.13':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.12':
+  '@biomejs/cli-darwin-x64@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.12':
+  '@biomejs/cli-linux-arm64-musl@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.12':
+  '@biomejs/cli-linux-arm64@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.12':
+  '@biomejs/cli-linux-x64-musl@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.12':
+  '@biomejs/cli-linux-x64@2.3.13':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.12':
+  '@biomejs/cli-win32-arm64@2.3.13':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.12':
+  '@biomejs/cli-win32-x64@2.3.13':
     optional: true
 
   '@electric-sql/pglite@0.3.15': {}
@@ -3237,14 +3237,14 @@ snapshots:
     dependencies:
       '@types/node': 25.0.10
 
-  '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.53.1
-      '@typescript-eslint/type-utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.53.1
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.54.0
       eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -3253,41 +3253,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.53.1
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.53.1
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.53.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.54.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.54.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.53.1':
+  '@typescript-eslint/scope-manager@8.54.0':
     dependencies:
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/visitor-keys': 8.53.1
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/visitor-keys': 8.54.0
 
-  '@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.54.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -3295,14 +3295,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.53.1': {}
+  '@typescript-eslint/types@8.54.0': {}
 
-  '@typescript-eslint/typescript-estree@8.53.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.54.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.53.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/visitor-keys': 8.53.1
+      '@typescript-eslint/project-service': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
       minimatch: 9.0.5
       semver: 7.7.3
@@ -3312,20 +3312,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.53.1
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.53.1':
+  '@typescript-eslint/visitor-keys@8.54.0':
     dependencies:
-      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/types': 8.54.0
       eslint-visitor-keys: 4.2.1
 
   '@vitest/expect@4.0.18':
@@ -4060,7 +4060,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.4: {}
+  lru-cache@11.2.5: {}
 
   luxon@3.7.2: {}
 
@@ -4191,14 +4191,14 @@ snapshots:
 
   path-scurry@2.0.1:
     dependencies:
-      lru-cache: 11.2.4
+      lru-cache: 11.2.5
       minipass: 7.1.2
 
   pathe@2.0.3: {}
 
   peberminta@0.9.0: {}
 
-  pg-boss@12.5.4:
+  pg-boss@12.6.0:
     dependencies:
       cron-parser: 5.5.0
       pg: 8.17.2
@@ -4573,12 +4573,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/src/lib/__generated__/kanel/index.ts
+++ b/src/lib/__generated__/kanel/index.ts
@@ -7,6 +7,7 @@ export { type ReplicacheClientId, type default as ReplicacheClientTable, type Re
 export { type UserSessionId, type default as UserSessionTable, type UserSession, type NewUserSession, type UserSessionUpdate, userSessionId, userSession, userSessionInitializer, userSessionMutator } from './public/UserSession';
 export { type default as PointLabelTable, type PointLabel, type NewPointLabel, type PointLabelUpdate, pointLabel, pointLabelInitializer, pointLabelMutator } from './public/PointLabel';
 export { type StreamId, type default as StreamTable, type Stream, type NewStream, type StreamUpdate, streamId, stream, streamInitializer, streamMutator } from './public/Stream';
+export { type MetaTaskId, type default as MetaTaskTable, type MetaTask, type NewMetaTask, type MetaTaskUpdate, metaTaskId, metaTask, metaTaskInitializer, metaTaskMutator } from './public/MetaTask';
 export { type PointId, type default as PointTable, type Point, type NewPoint, type PointUpdate, pointId, point, pointInitializer, pointMutator } from './public/Point';
 export { type default as PointWithLabelListTable, type PointWithLabelList, pointWithLabelList } from './public/PointWithLabelList';
 export { type default as PublicSchema } from './public/PublicSchema';

--- a/src/lib/__generated__/kanel/public/MetaTask.ts
+++ b/src/lib/__generated__/kanel/public/MetaTask.ts
@@ -1,0 +1,66 @@
+import { userId, type UserId } from './User';
+import type { ColumnType, Selectable, Insertable, Updateable } from 'kysely';
+import { z } from 'zod';
+
+/** Identifier type for public.meta_task */
+export type MetaTaskId = string & { __brand: 'public.meta_task' };
+
+/** Represents the table public.meta_task */
+export default interface MetaTaskTable {
+  id: ColumnType<MetaTaskId, MetaTaskId, MetaTaskId>;
+
+  userId: ColumnType<UserId, UserId, UserId>;
+
+  name: ColumnType<string, string, string>;
+
+  status: ColumnType<string, string, string>;
+
+  lastStartedAt: ColumnType<number, number, number>;
+
+  lastFinishedAt: ColumnType<number | null, number | null, number | null>;
+
+  createdAt: ColumnType<number, number, number>;
+
+  updatedAt: ColumnType<number, number, number>;
+}
+
+export type MetaTask = Selectable<MetaTaskTable>;
+
+export type NewMetaTask = Insertable<MetaTaskTable>;
+
+export type MetaTaskUpdate = Updateable<MetaTaskTable>;
+
+export const metaTaskId = z.string() as unknown as z.Schema<MetaTaskId>;
+
+export const metaTask = z.object({
+  id: metaTaskId,
+  userId: userId,
+  name: z.string(),
+  status: z.string(),
+  lastStartedAt: z.number(),
+  lastFinishedAt: z.number().nullable().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const metaTaskInitializer = z.object({
+  id: metaTaskId,
+  userId: userId,
+  name: z.string(),
+  status: z.string(),
+  lastStartedAt: z.number(),
+  lastFinishedAt: z.number().nullable().optional().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const metaTaskMutator = z.object({
+  id: metaTaskId.optional(),
+  userId: userId.optional(),
+  name: z.string().optional(),
+  status: z.string().optional(),
+  lastStartedAt: z.number().optional(),
+  lastFinishedAt: z.number().nullable().optional().nullable(),
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
+});

--- a/src/lib/__generated__/kanel/public/PublicSchema.ts
+++ b/src/lib/__generated__/kanel/public/PublicSchema.ts
@@ -7,6 +7,7 @@ import type { default as ReplicacheClientTable } from './ReplicacheClient';
 import type { default as UserSessionTable } from './UserSession';
 import type { default as PointLabelTable } from './PointLabel';
 import type { default as StreamTable } from './Stream';
+import type { default as MetaTaskTable } from './MetaTask';
 import type { default as PointTable } from './Point';
 import type { default as PointWithLabelListTable } from './PointWithLabelList';
 
@@ -28,6 +29,8 @@ export default interface PublicSchema {
   pointLabel: PointLabelTable;
 
   stream: StreamTable;
+
+  metaTask: MetaTaskTable;
 
   point: PointTable;
 

--- a/src/lib/__generated__/kanel/public/ReplicacheClientView.ts
+++ b/src/lib/__generated__/kanel/public/ReplicacheClientView.ts
@@ -11,6 +11,8 @@ export default interface ReplicacheClientViewTable {
   record: ColumnType<Record<string, unknown>, Record<string, unknown>, Record<string, unknown>>;
 
   createdAt: ColumnType<number, number, number>;
+
+  version: ColumnType<string, string, string>;
 }
 
 export type ReplicacheClientView = Selectable<ReplicacheClientViewTable>;
@@ -25,16 +27,19 @@ export const replicacheClientView = z.object({
   id: replicacheClientViewId,
   record: z.record(z.string(), z.unknown()),
   createdAt: z.number(),
+  version: z.string(),
 });
 
 export const replicacheClientViewInitializer = z.object({
   id: replicacheClientViewId,
   record: z.record(z.string(), z.unknown()),
   createdAt: z.number(),
+  version: z.string(),
 });
 
 export const replicacheClientViewMutator = z.object({
   id: replicacheClientViewId.optional(),
   record: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.number().optional(),
+  version: z.string().optional(),
 });

--- a/src/lib/components/Add/AddPointForm.svelte
+++ b/src/lib/components/Add/AddPointForm.svelte
@@ -83,9 +83,9 @@ const handleSubmit = async () => {
   }
 
   // TODO: what's the best way to handle this?
-  await store.mutate.migrate_fixupLabelParents({
-    startedAtGTE: currentTime,
-  })
+  // await store.mutate.migrate_fixupLabelParents({
+  //   startedAtGTE: currentTime,
+  // })
 
   goto('/log')
 }

--- a/src/lib/components/MetaTask/MetaTaskProgress.svelte
+++ b/src/lib/components/MetaTask/MetaTaskProgress.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import { onMount } from 'svelte'
+
+import type { Store } from '#lib/core/replicache/store.js'
+
+import { query } from '#lib/utils/query.js'
+
+type Props = {
+  store: Store
+  name: string
+}
+
+const { store, name }: Props = $props()
+
+let now = $state(Date.now())
+
+onMount(() => {
+  const timer = setTimeout(() => {
+    now = Date.now()
+  }, 1000)
+
+  return () => {
+    clearTimeout(timer)
+  }
+})
+
+const { metaTask } = $derived(
+  query({
+    metaTask: store.metaTask.find(`name===${name}`, (metaTask) => {
+      return metaTask.name === name
+    }),
+  }),
+)
+
+const durationMs = $derived(
+  metaTask
+    ? (metaTask.lastFinishedAt || now) - metaTask.lastStartedAt
+    : undefined,
+)
+</script>
+
+{#if metaTask}
+  <p>
+    <code>{metaTask.name}: {metaTask.status} {#if durationMs}({Math.round(durationMs / 1000)}s){/if}</code>
+  </p>
+{/if}

--- a/src/lib/core/replicache/get-replicache.ts
+++ b/src/lib/core/replicache/get-replicache.ts
@@ -16,6 +16,7 @@ import { asyncMapRecordValues } from '#lib/utils/record.js'
 import { mutators } from '#lib/mutator/index.js'
 
 import { subscribeToWebSocketPokes } from './poke.js'
+import { SCHEMA_VERSION } from './version.js'
 
 const createReplicacheMutators = async (
   initialContext: Omit<LocalMutatorContext, 'tx' | 'actionedAt'>,
@@ -66,7 +67,7 @@ const getReplicache = memoize(
     const context = { sessionUserId }
 
     const replicache = new Replicache<ReplicacheMutatorDefs>({
-      schemaVersion: '2026.01.27/0',
+      schemaVersion: SCHEMA_VERSION,
       name: sessionUserId,
       pushURL: '/api/internal/replicache/push',
       pullURL: '/api/internal/replicache/pull',

--- a/src/lib/core/replicache/keys.ts
+++ b/src/lib/core/replicache/keys.ts
@@ -1,4 +1,10 @@
-import type { LabelId, PointId, StreamId, UserId } from '#lib/ids.js'
+import type {
+  LabelId,
+  MetaTaskId,
+  PointId,
+  StreamId,
+  UserId,
+} from '#lib/ids.js'
 
 import { createKey } from '#lib/utils/create-key.js'
 
@@ -11,7 +17,8 @@ import { createKey } from '#lib/utils/create-key.js'
  */
 
 export const label = createKey('label')<LabelId>()
+export const meta = createKey('meta')<string>()
+export const metaTask = createKey('metaTask')<MetaTaskId>()
 export const point = createKey('point')<PointId>()
 export const stream = createKey('stream')<StreamId>()
 export const user = createKey('user')<UserId>()
-export const meta = createKey('meta')<string>()

--- a/src/lib/core/replicache/store.ts
+++ b/src/lib/core/replicache/store.ts
@@ -1,16 +1,29 @@
 import { transact } from 'signia'
-import type { ExperimentalDiffOperation as ReplicacheDiff } from 'replicache'
 
 import type {
   AnonLabel,
+  AnonMetaTask,
   AnonPoint,
   AnonStream,
   AnonUser,
   Replicache,
 } from '#lib/core/replicache/types.js'
-import type { LabelId, PointId, StreamId, UserId } from '#lib/ids.js'
+import type {
+  LabelId,
+  MetaTaskId,
+  PointId,
+  StreamId,
+  UserId,
+} from '#lib/ids.js'
 import type { InternalMutatorInput } from '#lib/mutator/types.js'
-import type { Label, Meta, Point, Stream, User } from '#lib/types.local.js'
+import type {
+  Label,
+  Meta,
+  MetaTask,
+  Point,
+  Stream,
+  User,
+} from '#lib/types.local.js'
 
 import * as Key from '#lib/core/replicache/keys.js'
 import { Table } from '#lib/core/replicache/table/table.js'
@@ -29,6 +42,10 @@ const createStore = (options: CreateStoreOptions) => {
   const meta = new Table<string, Meta, Meta>({
     key: Key.meta,
     mapValue: (value) => value,
+  })
+  const metaTask = new Table<MetaTaskId, AnonMetaTask, MetaTask>({
+    key: Key.metaTask,
+    mapValue: (value, id) => ({ id, ...value }),
   })
   const label = new Table<LabelId, AnonLabel, Label>({
     key: Key.label,
@@ -53,6 +70,7 @@ const createStore = (options: CreateStoreOptions) => {
     [Key.stream.name]: stream,
     [Key.label.name]: label,
     [Key.point.name]: point,
+    [Key.metaTask.name]: metaTask,
   }
 
   const setMetaState = (state: 'READY' | 'LOADING') => {
@@ -96,6 +114,7 @@ const createStore = (options: CreateStoreOptions) => {
     point,
     stream,
     user,
+    metaTask,
 
     mutate: mapRecordValues(
       rep.mutate,

--- a/src/lib/core/replicache/types.ts
+++ b/src/lib/core/replicache/types.ts
@@ -2,11 +2,12 @@ import type { Replicache as GenericReplicache } from 'replicache'
 import type { Except } from 'type-fest'
 
 import type { ReplicacheMutatorDefs } from '#lib/mutator/types.js'
-import type { Label, Point, Stream, User } from '#lib/types.local.js'
+import type { Label, MetaTask, Point, Stream, User } from '#lib/types.local.js'
 export type Replicache = GenericReplicache<ReplicacheMutatorDefs>
 type ExceptId<T extends { id: string }> = Except<T, 'id'>
 
-export type AnonUser = ExceptId<User>
 export type AnonLabel = ExceptId<Label>
+export type AnonMetaTask = ExceptId<MetaTask>
 export type AnonPoint = ExceptId<Point>
 export type AnonStream = ExceptId<Stream>
+export type AnonUser = ExceptId<User>

--- a/src/lib/core/replicache/version.ts
+++ b/src/lib/core/replicache/version.ts
@@ -1,0 +1,1 @@
+export const SCHEMA_VERSION = '2026.01.28/0'

--- a/src/lib/core/shape/build-line.ts
+++ b/src/lib/core/shape/build-line.ts
@@ -32,8 +32,6 @@ const buildLine = <PointLike extends Point>(
     startedAt,
     stoppedAt,
     durationMs,
-    createdAt: Math.max(startPoint.createdAt, stopPoint?.createdAt ?? 0),
-    updatedAt: Math.max(startPoint.updatedAt, stopPoint?.updatedAt ?? 0),
   }
 
   return line

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -1,6 +1,7 @@
 export type {
   EmailVerificationId,
   LabelId,
+  MetaTaskId,
   PointId,
   ReplicacheClientGroupId,
   ReplicacheClientId,

--- a/src/lib/mutator/label-create.ts
+++ b/src/lib/mutator/label-create.ts
@@ -6,7 +6,7 @@ import * as Key from '#lib/core/replicache/keys.js'
 import { deleteUndefinedKeys } from '#lib/utils/delete-undefined-keys.js'
 
 const labelCreate: LocalMutator<'label_create'> = async (context, options) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { labelId, streamId, parentId, name, color, icon } = options
 
   const key = Key.label.encode(labelId)
@@ -16,8 +16,6 @@ const labelCreate: LocalMutator<'label_create'> = async (context, options) => {
     color,
     icon,
     parentId,
-    createdAt: actionedAt,
-    updatedAt: actionedAt,
   })
   await tx.set(key, value)
 }

--- a/src/lib/mutator/label-rename.ts
+++ b/src/lib/mutator/label-rename.ts
@@ -4,7 +4,7 @@ import type { LocalMutator } from './types.ts'
 import * as Key from '#lib/core/replicache/keys.js'
 
 const labelRename: LocalMutator<'label_rename'> = async (context, options) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { labelId, name } = options
 
   const key = Key.label.encode(labelId)
@@ -16,7 +16,6 @@ const labelRename: LocalMutator<'label_rename'> = async (context, options) => {
   const value: AnonLabel = {
     ...label,
     name,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/label-set-color.ts
+++ b/src/lib/mutator/label-set-color.ts
@@ -7,7 +7,7 @@ const labelSetColor: LocalMutator<'label_setColor'> = async (
   context,
   options,
 ) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { labelId, color } = options
 
   const key = Key.label.encode(labelId)
@@ -19,7 +19,6 @@ const labelSetColor: LocalMutator<'label_setColor'> = async (
   const value: AnonLabel = {
     ...label,
     color,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/label-set-icon.ts
+++ b/src/lib/mutator/label-set-icon.ts
@@ -7,7 +7,7 @@ const labelSetIcon: LocalMutator<'label_setIcon'> = async (
   context,
   options,
 ) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { labelId, icon } = options
 
   const key = Key.label.encode(labelId)
@@ -19,7 +19,6 @@ const labelSetIcon: LocalMutator<'label_setIcon'> = async (
   const value: AnonLabel = {
     ...label,
     icon,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/label-set-parent.ts
+++ b/src/lib/mutator/label-set-parent.ts
@@ -7,7 +7,7 @@ const labelSetParent: LocalMutator<'label_setParent'> = async (
   context,
   options,
 ) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { labelId, parentId } = options
 
   const key = Key.label.encode(labelId)
@@ -19,7 +19,6 @@ const labelSetParent: LocalMutator<'label_setParent'> = async (
   const value: AnonLabel = {
     ...label,
     parentId,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/migrate-fixup-label-parents.server.ts
+++ b/src/lib/mutator/migrate-fixup-label-parents.server.ts
@@ -1,42 +1,13 @@
 import type { ServerMutator } from './types.ts'
 
-import { getStreamList } from '#lib/server/db/stream/get-stream-list.js'
-
-import { fixupLabelParents } from '#lib/server/migrate/fixup-label-parents.js'
+import { scheduleFixupLabelParents } from '#lib/server/worker.js'
 
 const migrateFixuplabelParents: ServerMutator<
   'migrate_fixupLabelParents'
-> = async (context, options) => {
-  const { db, sessionUserId } = context
-  const { startedAtGTE } = options
+> = async (context) => {
+  const { sessionUserId } = context
 
-  const streamList = await getStreamList({
-    db,
-    where: {
-      userId: sessionUserId,
-    },
-  })
-  if (streamList instanceof Error) {
-    return streamList
-  }
-
-  for (const stream of streamList) {
-    if (!stream.parentId) {
-      // ignore streams without a parent
-      continue
-    }
-    const result = await fixupLabelParents({
-      db,
-      streamId: stream.id,
-      parentStreamId: stream.parentId,
-      userId: sessionUserId,
-      startedAt: startedAtGTE > 0 ? { gte: startedAtGTE } : undefined,
-    })
-    if (result instanceof Error) {
-      console.error('fixupLabelParents error', result)
-      return result
-    }
-  }
+  await scheduleFixupLabelParents({ userId: sessionUserId })
 }
 
 export default migrateFixuplabelParents

--- a/src/lib/mutator/point-create.ts
+++ b/src/lib/mutator/point-create.ts
@@ -4,7 +4,7 @@ import type { LocalMutator } from './types.ts'
 import * as Key from '#lib/core/replicache/keys.js'
 
 const pointCreate: LocalMutator<'point_create'> = async (context, options) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { pointId, streamId, labelIdList, description, startedAt } = options
 
   const key = Key.point.encode(pointId)
@@ -13,8 +13,6 @@ const pointCreate: LocalMutator<'point_create'> = async (context, options) => {
     labelIdList,
     description,
     startedAt,
-    createdAt: actionedAt,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/point-slide.ts
+++ b/src/lib/mutator/point-slide.ts
@@ -4,7 +4,7 @@ import type { LocalMutator } from './types.ts'
 import * as Key from '#lib/core/replicache/keys.js'
 
 const pointSlide: LocalMutator<'point_slide'> = async (context, options) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { pointId, startedAt } = options
 
   const key = Key.point.encode(pointId)
@@ -16,7 +16,6 @@ const pointSlide: LocalMutator<'point_slide'> = async (context, options) => {
   const value: AnonPoint = {
     ...point,
     startedAt,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/stream-create.ts
+++ b/src/lib/mutator/stream-create.ts
@@ -7,7 +7,7 @@ const streamCreate: LocalMutator<'stream_create'> = async (
   context,
   options,
 ) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { streamId, name } = options
 
   let maxSortOrder = 0
@@ -25,8 +25,6 @@ const streamCreate: LocalMutator<'stream_create'> = async (
     name,
     parentId: undefined,
     sortOrder: nextSortOrder,
-    createdAt: actionedAt,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/stream-rename.ts
+++ b/src/lib/mutator/stream-rename.ts
@@ -7,7 +7,7 @@ const streamRename: LocalMutator<'stream_rename'> = async (
   context,
   options,
 ) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { streamId, name } = options
 
   const key = Key.stream.encode(streamId)
@@ -19,7 +19,6 @@ const streamRename: LocalMutator<'stream_rename'> = async (
   const value: AnonStream = {
     ...stream,
     name,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/stream-set-parent.ts
+++ b/src/lib/mutator/stream-set-parent.ts
@@ -7,7 +7,7 @@ const streamSetParent: LocalMutator<'stream_setParent'> = async (
   context,
   options,
 ) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { streamId, parentId } = options
 
   const key = Key.stream.encode(streamId)
@@ -19,7 +19,6 @@ const streamSetParent: LocalMutator<'stream_setParent'> = async (
   const value: AnonStream = {
     ...stream,
     parentId,
-    updatedAt: actionedAt,
   }
   await tx.set(key, value)
 }

--- a/src/lib/mutator/stream-sort.ts
+++ b/src/lib/mutator/stream-sort.ts
@@ -4,7 +4,7 @@ import type { LocalMutator } from './types.ts'
 import * as Key from '#lib/core/replicache/keys.js'
 
 const streamSort: LocalMutator<'stream_sort'> = async (context, options) => {
-  const { tx, actionedAt } = context
+  const { tx } = context
   const { streamId, delta } = options
 
   const streamList = await tx
@@ -43,7 +43,6 @@ const streamSort: LocalMutator<'stream_sort'> = async (context, options) => {
     await tx.set(key, {
       ...stream,
       sortOrder: i,
-      updatedAt: actionedAt,
     })
   }
 }

--- a/src/lib/mutator/types.ts
+++ b/src/lib/mutator/types.ts
@@ -65,9 +65,7 @@ type Mutators = {
     startedAt: number
   }>
 
-  migrate_fixupLabelParents: Mutator<{
-    startedAtGTE: number
-  }>
+  migrate_fixupLabelParents: Mutator<Record<string, never>>
 
   danger_deleteAllData: Mutator<{
     userHasConfirmed: boolean

--- a/src/lib/server/db/meta-task/get-meta-task-list.ts
+++ b/src/lib/server/db/meta-task/get-meta-task-list.ts
@@ -1,0 +1,35 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+
+import type { MetaTaskId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { Where } from '#lib/server/db/where.js'
+import type { MetaTask } from '#lib/server/types.js'
+
+import { extendWhere } from '#lib/server/db/where.js'
+
+type GetMetaTaskListOptions = {
+  db: KyselyDb
+  where: Where<{
+    userId: UserId
+    metaTaskId?: MetaTaskId
+  }>
+}
+
+const getMetaTaskList = async (
+  options: GetMetaTaskListOptions,
+): Promise<MetaTask[] | Error> => {
+  const { db, where } = options
+
+  return errorBoundary(() => {
+    let query = db.selectFrom('metaTask').selectAll()
+
+    query = extendWhere(query)
+      .string('id', where.metaTaskId)
+      .string('userId', where.userId)
+      .done()
+
+    return query.execute()
+  })
+}
+
+export { getMetaTaskList }

--- a/src/lib/server/db/meta-task/get-meta-task-version-record.ts
+++ b/src/lib/server/db/meta-task/get-meta-task-version-record.ts
@@ -1,0 +1,37 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+import { sql } from 'kysely'
+
+import type { MetaTaskId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { VersionRecord } from '#lib/server/replicache/cvr.js'
+
+import { buildVersionRecord } from '#lib/server/replicache/cvr.js'
+
+type GetMetaTaskVersionRecordOptions = {
+  db: KyselyDb
+  where: {
+    userId: UserId
+  }
+}
+
+const getMetaTaskVersionRecord = async (
+  options: GetMetaTaskVersionRecordOptions,
+): Promise<VersionRecord<MetaTaskId> | Error> => {
+  const { db, where } = options
+
+  const rowList = await errorBoundary(() =>
+    db
+      .selectFrom('metaTask')
+      .select('id')
+      .select(() => sql<number>`xmin`.as('version'))
+      .where('userId', '=', where.userId)
+      .execute(),
+  )
+  if (rowList instanceof Error) {
+    return rowList
+  }
+
+  return buildVersionRecord(rowList)
+}
+
+export { getMetaTaskVersionRecord }

--- a/src/lib/server/db/meta-task/update-meta-task.ts
+++ b/src/lib/server/db/meta-task/update-meta-task.ts
@@ -1,0 +1,45 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+
+import type { MetaTaskId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { Where } from '#lib/server/db/where.js'
+import type { MetaTask } from '#lib/server/types.js'
+
+import { extendWhere } from '#lib/server/db/where.js'
+
+type UpdateMetaTaskOptions = {
+  db: KyselyDb
+  where: Where<{
+    metaTaskId: MetaTaskId
+    userId: UserId
+  }>
+  set: Partial<Pick<MetaTask, 'status' | 'lastStartedAt' | 'lastFinishedAt'>>
+  now?: number
+}
+
+const updateMetaTask = async (
+  options: UpdateMetaTaskOptions,
+): Promise<MetaTask[] | Error> => {
+  const { db, where, set, now = Date.now() } = options
+
+  return errorBoundary(() => {
+    let query = db
+      .updateTable('metaTask')
+      .set({
+        status: set.status,
+        lastStartedAt: set.lastStartedAt,
+        lastFinishedAt: set.lastFinishedAt,
+        updatedAt: now,
+      })
+      .returningAll()
+
+    query = extendWhere(query)
+      .string('id', where.metaTaskId)
+      .string('userId', where.userId)
+      .done()
+
+    return query.execute()
+  })
+}
+
+export { updateMetaTask }

--- a/src/lib/server/db/meta-task/upsert-meta-task.ts
+++ b/src/lib/server/db/meta-task/upsert-meta-task.ts
@@ -1,0 +1,55 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+
+import type { MetaTaskId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { MetaTask } from '#lib/server/types.js'
+
+type UpsertMetaTaskOptions = {
+  db: KyselyDb
+  where: {
+    userId: UserId
+    name: string
+  }
+  insert: {
+    metaTaskId: MetaTaskId
+  }
+  set: {
+    status: string
+    lastStartedAt: number
+    lastFinishedAt: number | null
+  }
+  now?: number
+}
+
+const upsertMetaTask = async (
+  options: UpsertMetaTaskOptions,
+): Promise<MetaTask | Error> => {
+  const { db, where, insert, set, now = Date.now() } = options
+
+  const value: MetaTask = {
+    id: insert.metaTaskId,
+    userId: where.userId,
+    name: where.name,
+    status: set.status,
+    lastStartedAt: set.lastStartedAt,
+    lastFinishedAt: set.lastFinishedAt,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  return errorBoundary(() =>
+    db
+      .insertInto('metaTask')
+      .values(value)
+      .onConflict((ocb) =>
+        ocb.columns(['userId', 'name']).doUpdateSet({
+          ...set,
+          updatedAt: now,
+        }),
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow(),
+  )
+}
+
+export { upsertMetaTask }

--- a/src/lib/server/db/replicache-client-view/get-replicache-client-view.ts
+++ b/src/lib/server/db/replicache-client-view/get-replicache-client-view.ts
@@ -1,0 +1,30 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+
+import type { ReplicacheClientViewId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { ReplicacheClientView } from '#lib/server/types.js'
+
+type GetReplicacheClientViewOptions = {
+  db: KyselyDb
+  where: {
+    replicacheClientViewId: ReplicacheClientViewId
+    version: string
+  }
+}
+
+const getReplicacheClientView = async (
+  options: GetReplicacheClientViewOptions,
+): Promise<ReplicacheClientView | undefined | Error> => {
+  const { db, where } = options
+
+  return errorBoundary(() =>
+    db
+      .selectFrom('replicacheClientView')
+      .selectAll()
+      .where('id', '=', where.replicacheClientViewId)
+      .where('version', '=', where.version)
+      .executeTakeFirst(),
+  )
+}
+
+export { getReplicacheClientView }

--- a/src/lib/server/db/replicache-client-view/insert-replicache-client-view.ts
+++ b/src/lib/server/db/replicache-client-view/insert-replicache-client-view.ts
@@ -1,0 +1,40 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+
+import type { ReplicacheClientViewId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+import type { CVR } from '#lib/server/replicache/cvr.js'
+import type { ReplicacheClientView } from '#lib/server/types.js'
+
+type InsertReplicacheClientViewOptions = {
+  db: KyselyDb
+  where: {
+    replicacheClientViewId: ReplicacheClientViewId
+  }
+  set: {
+    record: CVR
+    version: string
+  }
+  now?: number
+}
+
+const insertReplicacheClientView = async (
+  options: InsertReplicacheClientViewOptions,
+): Promise<void | Error> => {
+  const { db, where, set, now = Date.now() } = options
+
+  const value: ReplicacheClientView = {
+    id: where.replicacheClientViewId,
+    record: set.record,
+    version: set.version,
+    createdAt: now,
+  }
+
+  const result = await errorBoundary(() =>
+    db.insertInto('replicacheClientView').values(value).execute(),
+  )
+  if (result instanceof Error) {
+    return result
+  }
+}
+
+export { insertReplicacheClientView }

--- a/src/lib/server/meta-task/track-meta-task.ts
+++ b/src/lib/server/meta-task/track-meta-task.ts
@@ -1,0 +1,102 @@
+import type { MetaTaskId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+
+import { updateMetaTask } from '#lib/server/db/meta-task/update-meta-task.js'
+import { upsertMetaTask } from '#lib/server/db/meta-task/upsert-meta-task.js'
+
+import { poke } from '#lib/server/replicache/poke/poke.js'
+
+import { genId } from '#lib/utils/gen-id.js'
+
+type MetaTaskOptions = {
+  db: KyselyDb
+  userId: UserId
+  name: string
+  status?: string
+}
+
+type MetaTaskResource = AsyncDisposable & {
+  complete: (options?: { status?: string }) => Promise<void>
+}
+
+const trackMetaTask = async (
+  options: MetaTaskOptions,
+): Promise<MetaTaskResource> => {
+  const { db, userId, name, status = 'Started' } = options
+
+  let metaTaskId: MetaTaskId | undefined
+  let isFinished = false
+
+  const metaTask = await upsertMetaTask({
+    db,
+    where: {
+      userId,
+      name,
+    },
+    insert: {
+      metaTaskId: genId(),
+    },
+    set: {
+      status,
+      lastStartedAt: Date.now(),
+      lastFinishedAt: null,
+    },
+  })
+  if (metaTask instanceof Error) {
+    console.error(metaTask)
+  } else {
+    poke(userId)
+    metaTaskId = metaTask.id
+  }
+
+  return {
+    async [Symbol.asyncDispose]() {
+      if (metaTaskId && !isFinished) {
+        const updatedMetaTask = await updateMetaTask({
+          db,
+          where: {
+            userId,
+            metaTaskId,
+          },
+          set: {
+            status: 'Error',
+            lastFinishedAt: Date.now(),
+          },
+        })
+        if (updatedMetaTask instanceof Error) {
+          console.error(updatedMetaTask)
+        } else {
+          poke(userId)
+        }
+      }
+    },
+    complete: async (options = {}) => {
+      const { status = 'Completed' } = options
+      if (!metaTaskId) {
+        return
+      }
+      if (isFinished) {
+        return
+      }
+      isFinished = true
+      const updatedMetaTask = await updateMetaTask({
+        db,
+        where: {
+          userId,
+          metaTaskId,
+        },
+        set: {
+          status,
+          lastFinishedAt: Date.now(),
+        },
+      })
+      if (updatedMetaTask instanceof Error) {
+        console.error(updatedMetaTask)
+      } else {
+        poke(userId)
+      }
+    },
+  }
+}
+
+export { trackMetaTask }

--- a/src/lib/server/migrate/fixup-all-label-parents.ts
+++ b/src/lib/server/migrate/fixup-all-label-parents.ts
@@ -1,0 +1,56 @@
+import type { UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+
+import { getStreamList } from '#lib/server/db/stream/get-stream-list.js'
+
+import { trackMetaTask } from '#lib/server/meta-task/track-meta-task.js'
+
+import { fixupLabelParents } from './fixup-label-parents.js'
+
+type FixupAllLabelParentsOptions = {
+  db: KyselyDb
+  userId: UserId
+}
+
+const fixupAllLabelParents = async (
+  options: FixupAllLabelParentsOptions,
+): Promise<void | Error> => {
+  const { db, userId } = options
+
+  await using metaTask = await trackMetaTask({
+    db,
+    userId,
+    name: 'fixup-all-label-parents',
+  })
+
+  const streamList = await getStreamList({
+    db,
+    where: {
+      userId,
+    },
+  })
+  if (streamList instanceof Error) {
+    return streamList
+  }
+
+  for (const stream of streamList) {
+    if (!stream.parentId) {
+      // ignore streams without a parent
+      continue
+    }
+    const result = await fixupLabelParents({
+      db,
+      streamId: stream.id,
+      parentStreamId: stream.parentId,
+      userId,
+    })
+    if (result instanceof Error) {
+      console.error('fixupLabelParents error', result)
+      return result
+    }
+  }
+
+  metaTask.complete()
+}
+
+export { fixupAllLabelParents }

--- a/src/lib/server/migrate/fixup-point-descriptions.ts
+++ b/src/lib/server/migrate/fixup-point-descriptions.ts
@@ -18,12 +18,13 @@ type FixupLabelParentsOptions = {
   streamId: StreamId
   parentStreamId: StreamId
   userId: UserId
+  startedAt?: { gte: number }
 }
 
-const fixupLabelParents = async (
+const fixupPointDescriptions = async (
   options: FixupLabelParentsOptions,
 ): Promise<void | Error> => {
-  const { db, streamId, parentStreamId, userId } = options
+  const { db, streamId, parentStreamId, userId, startedAt } = options
 
   const streamLabelList = await getLabelList({
     db,
@@ -142,7 +143,7 @@ const fixupLabelParents = async (
 
   const pointIterator = getPointIterator({
     db,
-    where: { userId, streamId },
+    where: { userId, streamId, startedAt },
     pageSize: PAGE_SIZE,
   })
 
@@ -225,4 +226,4 @@ const fixupLabelParents = async (
   }
 }
 
-export { fixupLabelParents }
+export { fixupPointDescriptions }

--- a/src/lib/server/replicache/cvr.ts
+++ b/src/lib/server/replicache/cvr.ts
@@ -1,5 +1,6 @@
 import type {
   LabelId,
+  MetaTaskId,
   PointId,
   ReplicacheClientId,
   StreamId,
@@ -8,19 +9,21 @@ import type {
 
 type VersionRecord<Key extends string> = Record<Key, number>
 type CVR = {
-  point: VersionRecord<PointId>
-  stream: VersionRecord<StreamId>
   label: VersionRecord<LabelId>
-  user: VersionRecord<UserId>
+  metaTask: VersionRecord<MetaTaskId>
+  point: VersionRecord<PointId>
   replicacheClient: VersionRecord<ReplicacheClientId>
+  stream: VersionRecord<StreamId>
+  user: VersionRecord<UserId>
 }
 
 const EMPTY_CVR: CVR = {
-  point: {},
-  stream: {},
   label: {},
-  user: {},
+  metaTask: {},
+  point: {},
   replicacheClient: {},
+  stream: {},
+  user: {},
 }
 const CVR_KEY_LIST = Object.keys(EMPTY_CVR) as (keyof CVR)[]
 

--- a/src/lib/server/snapshot/import-snapshot.ts
+++ b/src/lib/server/snapshot/import-snapshot.ts
@@ -2,6 +2,8 @@ import type { UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
 import type { Snapshot } from './schema.js'
 
+import { trackMetaTask } from '#lib/server/meta-task/track-meta-task.js'
+
 import { importLabelList } from './import/label.js'
 import { importPointList } from './import/point.js'
 import { importStreamList } from './import/stream.js'
@@ -17,7 +19,11 @@ const importSnapshot = async (
 ): Promise<void | Error> => {
   const { db, userId, snapshot } = options
 
-  console.info('[import-snapshot] Importing workspace...')
+  await using metaTask = await trackMetaTask({
+    db,
+    userId,
+    name: 'import-snapshot',
+  })
 
   // Note: Order is very important here
 
@@ -51,7 +57,7 @@ const importSnapshot = async (
     return new Error('Could not importPoints', { cause: pointIdMap })
   }
 
-  console.info('[import-snapshot] Completed import of workspace.')
+  await metaTask.complete()
 
   return undefined
 }

--- a/src/lib/server/types.ts
+++ b/src/lib/server/types.ts
@@ -4,6 +4,7 @@ import type { DB } from '#lib/server/db/types.js'
 
 export type EmailVerification = Selectable<DB['emailVerification']>
 export type Label = Selectable<DB['label']>
+export type MetaTask = Selectable<DB['metaTask']>
 export type Point = Selectable<DB['point']>
 export type PointLabel = Selectable<DB['pointLabel']>
 export type PointWithLabelList = Selectable<DB['pointWithLabelList']>

--- a/src/lib/server/worker.ts
+++ b/src/lib/server/worker.ts
@@ -1,14 +1,19 @@
 import { PgBoss } from 'pg-boss'
 
+import type { UserId } from '#lib/ids.js'
+
 import { getDatabaseUrl } from '#lib/server/env.js'
 
 import { getDb } from '#lib/server/db/get-db.js'
 
 import { garbageCollectEmailVerification } from '#lib/server/db/email-verification/garabage-collect-email-verification'
 
+import { fixupAllLabelParents } from '#lib/server/migrate/fixup-all-label-parents.js'
+
 import { once } from '#lib/utils/once.js'
 
 const GC_EMAIL_VERIFICATION = 'garbage-collect-email-verification'
+const FIXUP_LABEL_PARENTS = 'fixup-label-parents'
 
 const getBoss = once(() => {
   const databaseUrl = getDatabaseUrl()
@@ -23,11 +28,26 @@ const initBoss = () => {
     console.info('[worker] Starting boss…')
     await boss.start()
     await boss.createQueue(GC_EMAIL_VERIFICATION)
+    await boss.createQueue(FIXUP_LABEL_PARENTS)
 
     await boss.work(GC_EMAIL_VERIFICATION, async (_info) => {
       console.info('[worker] Garbage collecting email verifications…')
       const db = getDb()
       await garbageCollectEmailVerification({ db })
+    })
+
+    await boss.work<{ userId: UserId }>(FIXUP_LABEL_PARENTS, async (jobs) => {
+      console.info('[worker] Fixing up label parents…')
+      const db = getDb()
+      for (const job of jobs) {
+        const result = await fixupAllLabelParents({
+          db,
+          userId: job.data.userId,
+        })
+        if (result instanceof Error) {
+          throw result
+        }
+      }
     })
 
     await boss.schedule(GC_EMAIL_VERIFICATION, '0 0 * * *')
@@ -37,8 +57,14 @@ const initBoss = () => {
 
   return async () => {
     console.info('[worker] Stopping boss…')
-    await boss.offWork('garbage-collect-email-verification')
+    await boss.stop()
   }
 }
 
-export { getBoss, initBoss }
+const scheduleFixupLabelParents = async (options: { userId: UserId }) => {
+  const { userId } = options
+  const boss = getBoss()
+  await boss.send(FIXUP_LABEL_PARENTS, { userId })
+}
+
+export { getBoss, initBoss, scheduleFixupLabelParents }

--- a/src/lib/test/seed/get-minimal-initial-data.ts
+++ b/src/lib/test/seed/get-minimal-initial-data.ts
@@ -22,8 +22,6 @@ const getMinimalInitialData = (
     [`user/${sessionUserId}`]: {
       email: 'test@example.com',
       timeZone: 'UTC',
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
     } satisfies AnonUser,
   }
 }

--- a/src/lib/types.local.ts
+++ b/src/lib/types.local.ts
@@ -1,11 +1,15 @@
-import type { LabelId, PointId, StreamId, UserId } from '#lib/ids.js'
+import type {
+  LabelId,
+  MetaTaskId,
+  PointId,
+  StreamId,
+  UserId,
+} from '#lib/ids.js'
 
 type LocalUser = {
   readonly id: UserId
   email: string
   timeZone: string
-  createdAt: number
-  updatedAt: number
 }
 
 type LocalLabel = {
@@ -15,8 +19,6 @@ type LocalLabel = {
   icon: string | undefined
   color: string | undefined
   parentId: LabelId | undefined
-  createdAt: number
-  updatedAt: number
 }
 
 type LocalPoint = {
@@ -25,8 +27,6 @@ type LocalPoint = {
   labelIdList: readonly LabelId[]
   description: string
   startedAt: number
-  createdAt: number
-  updatedAt: number
 }
 
 type LocalStream = {
@@ -34,8 +34,14 @@ type LocalStream = {
   name: string
   sortOrder: number
   parentId: StreamId | undefined
-  createdAt: number
-  updatedAt: number
+}
+
+type LocalMetaTask = {
+  id: MetaTaskId
+  name: string
+  status: string
+  lastStartedAt: number
+  lastFinishedAt: number | undefined
 }
 
 type LocalMeta = {
@@ -48,4 +54,5 @@ export type {
   LocalPoint as Point,
   LocalStream as Stream,
   LocalMeta as Meta,
+  LocalMetaTask as MetaTask,
 }

--- a/src/routes/(app)/api/internal/import/+server.ts
+++ b/src/routes/(app)/api/internal/import/+server.ts
@@ -40,6 +40,8 @@ const POST: RequestHandler = async (event) => {
   }
 
   const db = getDb()
+
+  console.info('[import-snapshot] Importing workspace...')
   const result = await importSnapshot({
     db,
     userId: sessionUserId,
@@ -49,6 +51,7 @@ const POST: RequestHandler = async (event) => {
     console.error(printError(result))
     return new Response(result.message, { status: 500 })
   }
+  console.info('[import-snapshot] Completed import of workspace.')
 
   poke(sessionUserId)
 

--- a/src/routes/(app)/api/internal/replicache/pull/get-cvr.ts
+++ b/src/routes/(app)/api/internal/replicache/pull/get-cvr.ts
@@ -2,19 +2,27 @@ import type { PatchOperation, ReadonlyJSONValue } from 'replicache'
 
 import type {
   AnonLabel,
+  AnonMetaTask,
   AnonPoint,
   AnonStream,
   AnonUser,
 } from '#lib/core/replicache/types.js'
-import type { LabelId, UserId } from '#lib/ids.js'
+import type { LabelId, ReplicacheClientGroupId, UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
-import type { CVRDiff } from '#lib/server/replicache/cvr.js'
+import type { CVR, CVRDiff } from '#lib/server/replicache/cvr.js'
 import type { Key as GenericKey } from '#lib/utils/create-key.js'
 
 import { getLabelList } from '#lib/server/db/label/get-label-list.js'
+import { getLabelVersionRecord } from '#lib/server/db/label/get-label-version-record.js'
+import { getMetaTaskList } from '#lib/server/db/meta-task/get-meta-task-list.js'
+import { getMetaTaskVersionRecord } from '#lib/server/db/meta-task/get-meta-task-version-record.js'
 import { getPointList } from '#lib/server/db/point/get-point-list.js'
+import { getPointVersionRecord } from '#lib/server/db/point/get-point-version-record.js'
+import { getReplicacheClientVersionRecord } from '#lib/server/db/replicache-client/get-replicache-client-version-record.js'
 import { getStreamList } from '#lib/server/db/stream/get-stream-list.js'
+import { getStreamVersionRecord } from '#lib/server/db/stream/get-stream-version-record.js'
 import { getUserList } from '#lib/server/db/user/get-user-list.js'
+import { getUserVersionRecord } from '#lib/server/db/user/get-user-version-record.js'
 
 import * as Key from '#lib/core/replicache/keys.js'
 
@@ -43,6 +51,34 @@ const buildPatchList = <
     })
   }
   return patchList
+}
+
+type GetNextCVROptions = {
+  db: KyselyDb
+  sessionUserId: UserId
+  replicacheClientGroupId: ReplicacheClientGroupId
+}
+
+const getNextCVR = async (options: GetNextCVROptions): Promise<CVR | Error> => {
+  const { db, sessionUserId, replicacheClientGroupId } = options
+
+  return promiseAllRecord({
+    point: getPointVersionRecord({ db, where: { userId: sessionUserId } }),
+    stream: getStreamVersionRecord({
+      db,
+      where: { userId: sessionUserId },
+    }),
+    label: getLabelVersionRecord({ db, where: { userId: sessionUserId } }),
+    user: getUserVersionRecord({ db, where: { userId: sessionUserId } }),
+    metaTask: getMetaTaskVersionRecord({
+      db,
+      where: { userId: sessionUserId },
+    }),
+    replicacheClient: getReplicacheClientVersionRecord({
+      db,
+      where: { replicacheClientGroupId },
+    }),
+  })
 }
 
 type GetEntitiesOptions = {
@@ -76,6 +112,10 @@ const getEntities = async (
             where: { userId: sessionUserId },
           })
         : [],
+    metaTask: getMetaTaskList({
+      db,
+      where: { userId: sessionUserId, metaTaskId: { in: diff.metaTask.puts } },
+    }),
   })
   if (entities instanceof Error) {
     console.error(entities)
@@ -92,8 +132,6 @@ const getEntities = async (
         labelIdList: entity.labelIdList as LabelId[],
         description: entity.description,
         startedAt: entity.startedAt,
-        createdAt: entity.createdAt,
-        updatedAt: entity.updatedAt,
       }),
     ),
     buildPatchList(
@@ -106,8 +144,6 @@ const getEntities = async (
         icon: entity.icon ?? undefined,
         color: entity.color ?? undefined,
         parentId: entity.parentId ?? undefined,
-        createdAt: entity.createdAt,
-        updatedAt: entity.updatedAt,
       }),
     ),
     buildPatchList(
@@ -118,8 +154,6 @@ const getEntities = async (
         name: entity.name,
         parentId: entity.parentId ?? undefined,
         sortOrder: entity.sortOrder,
-        createdAt: entity.createdAt,
-        updatedAt: entity.updatedAt,
       }),
     ),
     buildPatchList(
@@ -129,11 +163,20 @@ const getEntities = async (
       (entity): AnonUser => ({
         email: entity.email,
         timeZone: entity.timeZone,
-        createdAt: entity.createdAt,
-        updatedAt: entity.updatedAt,
+      }),
+    ),
+    buildPatchList(
+      Key.metaTask,
+      diff.metaTask,
+      entities.metaTask,
+      (entity): AnonMetaTask => ({
+        name: entity.name,
+        status: entity.status,
+        lastStartedAt: entity.lastStartedAt,
+        lastFinishedAt: entity.lastFinishedAt ?? undefined,
       }),
     ),
   )
 }
 
-export { getEntities }
+export { getNextCVR, getEntities }

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -3,6 +3,7 @@ import { dropAllDatabases } from 'replicache'
 
 import type { PageProps } from './$types'
 
+import MetaTaskProgress from '#lib/components/MetaTask/MetaTaskProgress.svelte'
 import StreamManager from '#lib/components/StreamManager/StreamManager.svelte'
 
 const { data }: PageProps = $props()
@@ -49,9 +50,7 @@ const handleDeleteAllData = async () => {
 }
 
 const handleAssignLabelParent = async () => {
-  await store.mutate.migrate_fixupLabelParents({
-    startedAtGTE: 0,
-  })
+  await store.mutate.migrate_fixupLabelParents({})
 }
 </script>
 
@@ -73,6 +72,7 @@ const handleAssignLabelParent = async () => {
     <h2>Assign Parent Labels</h2>
     <p>Scan existing labels and associate them with the correct parent.</p>
     <button onclick={handleAssignLabelParent}>Assign Label Parent</button>
+    <MetaTaskProgress {store} name="fixup-all-label-parents" />
   </section>
 
   <section>
@@ -85,6 +85,7 @@ const handleAssignLabelParent = async () => {
     <h3>Import</h3>
     <p>Import data from a JSON file.</p>
     <button onclick={handleImport}>Import</button>
+    <MetaTaskProgress {store} name="import-snapshot" />
 
     <details class="dangerZone">
       <summary>⚠️ Danger Zone</summary>


### PR DESCRIPTION
## Summary
Add a new meta_task system for tracking long-running/async work, persist client-view version records for Replicache, and bump a few dev/runtime dependencies.

## Changes
- Database & migrations
  - Add two new migrations (migrations/committed/000006.sql, 000007.sql) to create the public.meta_task table and add a version column to replicache_client_view.
  - Update schema.sql to include meta_task table and constraints.
- Server-side meta-task support
  - New server APIs/helpers: trackMetaTask, upsertMetaTask, updateMetaTask, getMetaTaskList, getMetaTaskVersionRecord.
  - Introduced fixup-all-label-parents worker task and a scheduleFixupLabelParents helper; migrate_fixupLabelParents now enqueues work instead of running sync.
  - importSnapshot now reports progress via meta_task and calls trackMetaTask.
- Replicache / CVR changes
  - Persist client view records to DB (replicacheClientView) and use stored CVR when computing diffs; added SCHEMA_VERSION constant and migrated pull logic to use DB-backed CVR (new get-cvr.ts).
  - Added version column to Replicache client-view types and kanel-generated types updated accordingly.
- Local store & UI
  - Added MetaTask to client-side store, keys, types, and a MetaTaskProgress Svelte component; settings page shows progress for import and fixup tasks.
  - Several client mutators no longer set createdAt/updatedAt locally (timestamps handled elsewhere).
- Dependencies & tooling
  - Bumped pg-boss, @biomejs/biome, typescript-eslint and updated pnpm lockfile.

## Migration / breaking changes
- Run DB migrations to create the meta_task table and add the version column to replicache_client_view before deploying.
- Restart the background worker (pg-boss) so the new queues and scheduleFixupLabelParents are registered.
- Replicache schema version constant changed (SCHEMA_VERSION). Clients and server should be deployed together to avoid CVR/version mismatches.

If you have CI that pins migrations or requires manual migration steps, apply the new SQL files and restart services that interact with the worker/replicache endpoints.