### PR TITLE
fix(log): align slice rows in SliceList grid

### DIFF
--- a/src/lib/components/Log/SliceList.svelte
+++ b/src/lib/components/Log/SliceList.svelte
@@ -44,10 +44,10 @@ const streamColumnIndex: Record<StreamId, number> = $derived(
 
   {#each sliceList as slice, index (index)}
     <section>
-      <div class="cell" style:--col="1"><a href="/edit/slice/{slice.startedAt}">{formatTime(timeZone, slice.startedAt)}</a></div>
+      <div class="cell" style:--row={index + 2} style:--col="1"><a href="/edit/slice/{slice.startedAt}">{formatTime(timeZone, slice.startedAt)}</a></div>
 
       {#each slice.lineList as line (line.streamId)}
-        <div class="cell" style:--col={2 + (streamColumnIndex[line.streamId] ?? 0)}>
+        <div class="cell" style:--row={index + 2} style:--col={2 + (streamColumnIndex[line.streamId] ?? 0)}>
           {#if line}
             <Line {store} {line} />
           {/if}
@@ -69,6 +69,7 @@ const streamColumnIndex: Record<StreamId, number> = $derived(
 
 	.cell {
     grid-column: var(--col);
+    grid-row: var(--row);
 		white-space: pre-wrap;
 	}
 </style>


### PR DESCRIPTION
## Summary
Fix the grid layout in src/lib/components/Log/SliceList.svelte so each slice (timestamp/link) and its line items share the same grid row, improving alignment and readability.

## Changes
- Add row positioning to slice header cell: set style:--row={index + 2} on the timestamp/link cell.
- Apply same row variable to each line cell so line items render in the same row as their parent slice.
- Add grid-row: var(--row) to the .cell CSS and keep existing grid-column usage for column placement.
- Visual/user impact: UI layout is corrected—timestamps, links, and line items now align cleanly; no logic or data changes.
- Compatibility note: No migrations or config changes required. Consumers who relied on implicit grid placement or custom CSS targeting .cell may need to update styles to account for the new grid-row variable.