### PR TITLE
feat(mutator): add point_delete mutator and UI delete action

### DIFF
--- a/src/lib/components/MultiSelect/MultiSelect.svelte
+++ b/src/lib/components/MultiSelect/MultiSelect.svelte
@@ -141,7 +141,9 @@ const handleRemoveAll = () => {
           onmousedown={(event) => { event.stopImmediatePropagation(); event.preventDefault(); handleAdd(option.value) }}>{option.label}</button>
       {/each}
       {#if searchQuery.length > 0}
-        <button type="button" onclick={handleCreate}>Create: {searchQuery}</button>
+        <button
+          type="button"
+          onmousedown={(event) => { event.stopImmediatePropagation(); event.preventDefault(); handleCreate() }}>Create: {searchQuery}</button>
       {/if}
     </div>
   {/if}

--- a/src/lib/mutator/index.server.ts
+++ b/src/lib/mutator/index.server.ts
@@ -15,6 +15,7 @@ const mutators: ServerMutatorDefsImportMap = {
 
   point_create: import('./point-create.server.js'),
   point_slide: import('./point-slide.server.js'),
+  point_delete: import('./point-delete.server.js'),
 
   migrate_fixupLabelParents: import('./migrate-fixup-label-parents.server.js'),
 

--- a/src/lib/mutator/index.ts
+++ b/src/lib/mutator/index.ts
@@ -15,6 +15,7 @@ const mutators: LocalMutatorDefsImportMap = {
 
   point_create: import('./point-create.js'),
   point_slide: import('./point-slide.js'),
+  point_delete: import('./point-delete.js'),
 
   migrate_fixupLabelParents: import('./migrate-fixup-label-parents.js'),
 

--- a/src/lib/mutator/point-delete.server.ts
+++ b/src/lib/mutator/point-delete.server.ts
@@ -1,0 +1,21 @@
+import type { ServerMutator } from './types.ts'
+
+import { bulkDeletePoint } from '#lib/server/db/point/bulk-delete-point.js'
+
+const pointDelete: ServerMutator<'point_delete'> = async (context, options) => {
+  const { db } = context
+  const { pointId } = options
+
+  const result = await bulkDeletePoint({
+    db,
+    where: {
+      userId: context.sessionUserId,
+      pointId,
+    },
+  })
+  if (result instanceof Error) {
+    return result
+  }
+}
+
+export default pointDelete

--- a/src/lib/mutator/point-delete.ts
+++ b/src/lib/mutator/point-delete.ts
@@ -1,0 +1,13 @@
+import type { LocalMutator } from './types.ts'
+
+import * as Key from '#lib/core/replicache/keys.js'
+
+const pointDelete: LocalMutator<'point_delete'> = async (context, options) => {
+  const { tx } = context
+  const { pointId } = options
+
+  const key = Key.point.encode(pointId)
+  await tx.del(key)
+}
+
+export default pointDelete

--- a/src/lib/mutator/types.ts
+++ b/src/lib/mutator/types.ts
@@ -64,6 +64,9 @@ type Mutators = {
     pointId: PointId
     startedAt: number
   }>
+  point_delete: Mutator<{
+    pointId: PointId
+  }>
 
   migrate_fixupLabelParents: Mutator<Record<string, never>>
 

--- a/src/routes/(app)/edit/slice/[startedAt]/+page.svelte
+++ b/src/routes/(app)/edit/slice/[startedAt]/+page.svelte
@@ -29,9 +29,8 @@ let timestamp = $derived(
   formatInTimeZone(startedAt, timeZone, 'yyyy-MM-dd HH:mm'),
 )
 
-const handleSubmit = async (event: SubmitEvent) => {
+const handleSlide = async (event: SubmitEvent) => {
   event.preventDefault()
-
   const nextStartedAt = toDate(timestamp, { timeZone }).getTime()
   if (startedAt !== nextStartedAt) {
     for (const point of Object.values(pointRecord)) {
@@ -44,11 +43,26 @@ const handleSubmit = async (event: SubmitEvent) => {
     }
   }
 
-  goto('/log')
+  await goto('/log')
+}
+
+const handleDelete = async () => {
+  const confirm = window.confirm('Are you sure you want to delete this point?')
+  if (!confirm) {
+    return
+  }
+
+  for (const point of Object.values(pointRecord)) {
+    if (point.startedAt === startedAt) {
+      await store.mutate.point_delete({ pointId: point.id })
+    }
+  }
+
+  await goto('/log')
 }
 </script>
 
-<form onsubmit={handleSubmit}>
+<form onsubmit={handleSlide}>
   <input
     type="datetime-local"
     name="startedAtLocal"
@@ -78,6 +92,8 @@ const handleSubmit = async (event: SubmitEvent) => {
     {/if}
   {/each}
 </ul>
+
+<button type="button" onclick={handleDelete}>Delete Points</button>
 
 <style>
   li.stream:not(.isActive) {


### PR DESCRIPTION
## Summary
Add support for deleting points via a new mutator and expose a Delete button in the slice edit page. Also fix button event handling in the MultiSelect component to prevent accidental interactions.

## Changes
- Mutators
  - Added server and local mutators: src/lib/mutator/point-delete.server.ts and src/lib/mutator/point-delete.ts
  - Registered `point_delete` in mutator index files (index.server.ts and index.ts)
  - Added `point_delete` to mutator types (src/lib/mutator/types.ts)
- UI / page behavior
  - Replaced handleSubmit with handleSlide and added handleDelete in src/routes/(app)/edit/slice/[startedAt]/+page.svelte
  - Added a "Delete Points" button that prompts for confirmation and calls store.mutate.point_delete for points matching the current startedAt
- Bugfix
  - Improve MultiSelect create-button handling: use onmousedown and stop default/propagation to avoid unintended interactions

## Notes / Impacts
- User-visible: a new Delete Points button is available on the slice edit page to remove points for the signed-in user.
- Server-side deletion is scoped to the session user (only points belonging to the current user will be deleted).
- No DB schema migrations required. No breaking changes expected; callers can now use the new `point_delete` mutator.