### PR TITLE
fix(snapshot): sort labels parents-first during import

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -174,16 +174,13 @@
           },
           "style": {
             "useConst": "off",
-            "useImportType": "off",
-
-            // TODO: refactor components to avoid using null assertions
-            "noNonNullAssertion": "off"
+            "useImportType": "off"
           }
         }
       }
     },
     {
-      "includes": ["**/*.stories.svelte"],
+      "includes": ["**/*.test.ts", "**/*.stories.svelte"],
       "linter": {
         "rules": {
           "style": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3872,7 +3872,7 @@ snapshots:
   extract-pg-schema@5.8.1(@electric-sql/pglite@0.3.15):
     dependencies:
       knex: 3.1.0(pg@8.17.2)
-      knex-pglite: 0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.17.2))
+      knex-pglite: 0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.18.0))
       pg: 8.17.2
       pg-query-emscripten: 5.1.0
       ramda: 0.31.3
@@ -4173,7 +4173,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knex-pglite@0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.17.2)):
+  knex-pglite@0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.18.0)):
     dependencies:
       '@electric-sql/pglite': 0.3.15
       knex: 3.1.0(pg@8.17.2)

--- a/src/lib/server/db/label/bulk-delete-label.ts
+++ b/src/lib/server/db/label/bulk-delete-label.ts
@@ -1,5 +1,6 @@
 import { errorBoundary } from '@stayradiated/error-boundary'
 import type { DeleteResult } from 'kysely'
+import { sql } from 'kysely'
 
 import type { LabelId, UserId } from '#lib/ids.js'
 import type { KyselyDb } from '#lib/server/db/types.js'
@@ -20,15 +21,30 @@ const bulkDeleteLabel = async (
 ): Promise<DeleteResult | Error> => {
   const { db, where } = options
 
-  return errorBoundary(() => {
-    let query = db.deleteFrom('label')
+  return errorBoundary(async () => {
+    let query = db.selectFrom('label').select('id')
 
     query = extendWhere(query)
       .string('id', where.labelId)
       .string('userId', where.userId)
       .done()
 
-    return query.executeTakeFirstOrThrow()
+    const list = await query.execute()
+    const labelIdList = list.map((row) => row.id)
+
+    if (labelIdList.length === 0) {
+      return { numDeletedRows: 0n } satisfies DeleteResult
+    }
+
+    await db
+      .deleteFrom('labelParent')
+      .where((eb) => eb('labelId', '=', eb.fn.any(sql.val(labelIdList))))
+      .executeTakeFirstOrThrow()
+
+    return db
+      .deleteFrom('label')
+      .where((eb) => eb('id', '=', eb.fn.any(sql.val(labelIdList))))
+      .executeTakeFirstOrThrow()
   })
 }
 

--- a/src/lib/server/db/label/insert-label.ts
+++ b/src/lib/server/db/label/insert-label.ts
@@ -36,7 +36,7 @@ const insertLabel = async (
     }),
   )
 
-  return transact('insertLabel', db, async () => {
+  return transact('insertLabel', db, async ({ db }) => {
     await db
       .insertInto('label')
       .values(value)

--- a/src/lib/server/db/label/update-label.ts
+++ b/src/lib/server/db/label/update-label.ts
@@ -23,7 +23,7 @@ const updateLabel = async (
 ): Promise<void | Error> => {
   const { db, where, set, now = Date.now() } = options
 
-  return transact('updateLabel', db, async () => {
+  return transact('updateLabel', db, async ({ db }) => {
     /*
      * note: eevn if there are no properties to update, we still need to
      * update the timestamps - to ensure that the row is marked as changed

--- a/src/lib/server/snapshot/legacy-snapshot.ts
+++ b/src/lib/server/snapshot/legacy-snapshot.ts
@@ -84,8 +84,8 @@ const migrateLegacySnapshot = (legacySnapshot: LegacySnapshot): Snapshot => {
         updatedAt: stream.updatedAt ?? stream.createdAt,
       }),
     ),
-    label: Object.values(legacySnapshot.label)
-      .map((label): Snapshot['label'][number] => ({
+    label: Object.values(legacySnapshot.label).map(
+      (label): Snapshot['label'][number] => ({
         id: label.id,
         streamId: label.streamId,
         name: label.name,
@@ -94,12 +94,8 @@ const migrateLegacySnapshot = (legacySnapshot: LegacySnapshot): Snapshot => {
         parentLabelIdList: label.parentId ? [label.parentId] : [],
         createdAt: label.createdAt,
         updatedAt: label.updatedAt ?? label.createdAt,
-      }))
-      .sort((a, b) => {
-        return (a.parentLabelIdList.at(0) ?? '').localeCompare(
-          b.parentLabelIdList.at(0) ?? '',
-        )
       }),
+    ),
     point: Object.values(legacySnapshot.point).map(
       (point): Snapshot['point'][number] => ({
         id: point.id,

--- a/src/lib/utils/topo-sort-parents-first.test.ts
+++ b/src/lib/utils/topo-sort-parents-first.test.ts
@@ -1,0 +1,189 @@
+import { test } from 'vitest'
+
+import { topoSortParentsFirst } from './topo-sort-parents-first.js'
+
+type Item = {
+  id: string
+  parents: string[]
+  name?: string
+}
+
+const run = (items: readonly Item[]) =>
+  topoSortParentsFirst({
+    items,
+    getId: (x) => x.id,
+    getParentIdList: (x) => x.parents,
+  })
+
+const isError = (x: unknown): x is Error => x instanceof Error
+
+const ids = (x: Item[] | Error) => (isError(x) ? x : x.map((i) => i.id))
+
+const assertParentsBeforeChildren = (sorted: Item[]) => {
+  const index: Record<string, number> = {}
+  for (let i = 0; i < sorted.length; i += 1) {
+    index[sorted[i]!.id] = i
+  }
+
+  for (const item of sorted) {
+    for (const p of item.parents) {
+      if (index[p] === undefined) {
+        throw new Error(`Test setup error: parent ${p} not in sorted list`)
+      }
+      if (!(index[p] < index[item.id]!)) {
+        throw new Error(`Expected parent ${p} before child ${item.id}`)
+      }
+    }
+  }
+}
+
+test('returns items in the same order when there are no parents', ({
+  expect,
+}) => {
+  const items: Item[] = [
+    { id: 'a', parents: [] },
+    { id: 'b', parents: [] },
+    { id: 'c', parents: [] },
+  ]
+
+  const out = run(items)
+  expect(out).not.toBeInstanceOf(Error)
+  expect(ids(out)).toEqual(['a', 'b', 'c'])
+})
+
+test('sorts a simple chain: a -> b -> c (parent first)', ({ expect }) => {
+  const items: Item[] = [
+    { id: 'c', parents: ['b'] },
+    { id: 'b', parents: ['a'] },
+    { id: 'a', parents: [] },
+  ]
+
+  const out = run(items)
+  expect(out).not.toBeInstanceOf(Error)
+  expect(ids(out)).toEqual(['a', 'b', 'c'])
+})
+
+test('sorts a branching tree (parent first for all edges)', ({ expect }) => {
+  // a is parent of b and c; c is parent of d
+  const items: Item[] = [
+    { id: 'd', parents: ['c'] },
+    { id: 'c', parents: ['a'] },
+    { id: 'b', parents: ['a'] },
+    { id: 'a', parents: [] },
+  ]
+
+  const out = run(items)
+  expect(out).not.toBeInstanceOf(Error)
+
+  const sorted = out as Item[]
+  expect(sorted).toHaveLength(items.length)
+  assertParentsBeforeChildren(sorted)
+
+  // optional: sanity check root is first here (not required by topo sort generally,
+  // but given the inputs it should be)
+  expect(sorted[0]!.id).toBe('a')
+})
+
+test('supports multiple parents per item', ({ expect }) => {
+  // a and b are both parents of c
+  const items: Item[] = [
+    { id: 'c', parents: ['a', 'b'] },
+    { id: 'b', parents: [] },
+    { id: 'a', parents: [] },
+  ]
+
+  const out = run(items)
+  expect(out).not.toBeInstanceOf(Error)
+
+  const sorted = out as Item[]
+  assertParentsBeforeChildren(sorted)
+  expect(sorted.at(-1)?.id).toBe('c')
+})
+
+test('keeps relative order among independent roots (stable-ish with this implementation)', ({
+  expect,
+}) => {
+  // Implementation detail: queue is seeded in input order, so independent nodes keep order.
+  const items: Item[] = [
+    { id: 'root1', parents: [] },
+    { id: 'root2', parents: [] },
+    { id: 'child', parents: ['root1'] },
+  ]
+
+  const out = run(items)
+  expect(out).not.toBeInstanceOf(Error)
+  expect(ids(out)).toEqual(['root1', 'root2', 'child'])
+})
+
+test('returns Error for duplicate IDs', ({ expect }) => {
+  const items: Item[] = [
+    { id: 'a', parents: [] },
+    { id: 'a', parents: [] },
+  ]
+
+  const out = run(items)
+  expect(out).toBeInstanceOf(Error)
+  expect((out as Error).message).toMatch(/Duplicate ID: a/)
+})
+
+test('returns Error for missing parent', ({ expect }) => {
+  const items: Item[] = [{ id: 'child', parents: ['missing'] }]
+
+  const out = run(items)
+  expect(out).toBeInstanceOf(Error)
+  expect((out as Error).message).toMatch(/Missing parent: missing/)
+})
+
+test('returns Error for a simple cycle (a <-> b)', ({ expect }) => {
+  const items: Item[] = [
+    { id: 'a', parents: ['b'] },
+    { id: 'b', parents: ['a'] },
+  ]
+
+  const out = run(items)
+  expect(out).toBeInstanceOf(Error)
+  expect((out as Error).message).toBe('Cycle detected')
+})
+
+test('returns Error for a longer cycle (a -> b -> c -> a)', ({ expect }) => {
+  const items: Item[] = [
+    { id: 'a', parents: ['c'] },
+    { id: 'b', parents: ['a'] },
+    { id: 'c', parents: ['b'] },
+  ]
+
+  const out = run(items)
+  expect(out).toBeInstanceOf(Error)
+  expect((out as Error).message).toBe('Cycle detected')
+})
+
+test('handles a mix: one acyclic component plus one cycle (should error)', ({
+  expect,
+}) => {
+  const items: Item[] = [
+    // acyclic piece
+    { id: 'root', parents: [] },
+    { id: 'leaf', parents: ['root'] },
+
+    // cyclic piece
+    { id: 'x', parents: ['y'] },
+    { id: 'y', parents: ['x'] },
+  ]
+
+  const out = run(items)
+  expect(out).toBeInstanceOf(Error)
+  expect((out as Error).message).toBe('Cycle detected')
+})
+
+test('does not mutate the input items array or item objects', ({ expect }) => {
+  const items: Item[] = [
+    { id: 'b', parents: ['a'], name: 'B' },
+    { id: 'a', parents: [], name: 'A' },
+  ]
+
+  const snapshot = structuredClone(items)
+  const out = run(items)
+
+  expect(out).not.toBeInstanceOf(Error)
+  expect(items).toEqual(snapshot)
+})

--- a/src/lib/utils/topo-sort-parents-first.ts
+++ b/src/lib/utils/topo-sort-parents-first.ts
@@ -1,0 +1,99 @@
+/**
+ * Sort a list of items so that parents are listed before children.
+ */
+
+type TopoSortParentsFirstOptions<T, Id> = {
+  items: readonly T[]
+  getId: (item: T) => Id
+  getParentIdList: (item: T) => readonly Id[]
+}
+
+const topoSortParentsFirst = <T, Id extends string>(
+  options: TopoSortParentsFirstOptions<T, Id>,
+): T[] | Error => {
+  const { items, getId, getParentIdList } = options
+
+  // 1) Index by ID and validate uniqueness
+  const byId = {} as Record<Id, T>
+  for (const item of items) {
+    const id = getId(item)
+    if (id in byId) {
+      return new Error(`Duplicate ID: ${id}`)
+    }
+    byId[id] = item
+  }
+
+  // 2) Build graph: parent → children, plus indegree counts
+  const childrenByParent = {} as Record<Id, Id[]>
+  const inDegree = {} as Record<Id, number>
+  for (const item of items) {
+    const id = getId(item)
+    childrenByParent[id] = []
+    inDegree[id] = 0
+  }
+  for (const child of items) {
+    const childId = getId(child)
+    for (const parentId of getParentIdList(child)) {
+      if (!(parentId in byId)) {
+        return new Error(`Missing parent: ${parentId}`)
+      }
+      childrenByParent[parentId].push(childId)
+      inDegree[childId] += 1
+    }
+  }
+
+  // 3) Queue all nodes with 0 incoming edges
+  const queue: Id[] = []
+  for (const item of items) {
+    const id = getId(item)
+    if (inDegree[id] === 0) {
+      queue.push(id)
+    }
+  }
+
+  // 4) Pop from queue, emit item, "remove" it's outgoing edges
+  const result: T[] = []
+  let i = 0
+  while (i < queue.length) {
+    const id = queue[i]
+    if (typeof id === 'undefined') {
+      throw new Error('Internal error: queue item is undefined')
+    }
+
+    const item = byId[id]
+    if (typeof item === 'undefined') {
+      throw new Error('Internal error: item is undefined')
+    }
+
+    result.push(item)
+
+    const childIdList = childrenByParent[id]
+    if (typeof childIdList === 'undefined') {
+      throw new Error('Internal error: childIdList is undefined')
+    }
+
+    for (const childId of childIdList) {
+      let degree = inDegree[childId]
+      if (typeof degree === 'undefined') {
+        throw new Error('Internal error: degree is undefined')
+      }
+
+      degree -= 1
+      inDegree[childId] = degree
+      if (degree === 0) {
+        queue.push(childId)
+      }
+    }
+
+    i += 1
+  }
+
+  // 5) If not everything was popped, there was a cycle
+  if (result.length !== items.length) {
+    return new Error('Cycle detected')
+  }
+
+  return result
+}
+
+export { topoSortParentsFirst }


### PR DESCRIPTION
## Summary
Ensure label parents are inserted before their children during snapshot import to reliably resolve parent IDs and catch invalid snapshots earlier.

## Changes
- Snapshot import
  - Added topoSortParentsFirst utility to topologically sort items so parents come before children.
  - Use topoSortParentsFirst when importing labels; import now fails fast with an Error for duplicate IDs, missing parents, or cycles.
  - Updated legacy snapshot migration to use the new ordering.

- Database / transaction behavior
  - Wrap several DB operations with transact (insert-label, update-label, upsert-point) and adjust call signatures accordingly.
  - bulk-delete-label now collects matching label IDs, deletes related labelParent rows first, then deletes labels (preserves referential integrity).
  - upsert-point skips inserting into pointLabel when the label list is empty.

- Tests & config
  - Added unit tests for topoSortParentsFirst covering edge cases (duplicates, cycles, missing parents) to prevent regressions.
  - biome.jsonc updated to include test files for linting.
  - pnpm-lock.yaml updated (dependency snapshot tweak).

## Impacts & migration notes
- User-visible: snapshot imports will now error if the label graph contains cycles, duplicate IDs, or references missing parents; this surfaces invalid/legacy data earlier.
- DB: bulk delete now also removes labelParent rows. No external migration required, but behavior is stricter about referential integrity.
- Internal: transact usage was adjusted in a few modules; this is an internal call-site change (no public API changes expected).