### PR TITLE
feat: add label usage tracking functionality 📊

### DIFF
--- a/src/lib/components/Add/PointInput.svelte
+++ b/src/lib/components/Add/PointInput.svelte
@@ -54,11 +54,17 @@ type Option = {
 
 const toOption = (label: Pick<Label, 'id' | 'icon' | 'name'>): Option => ({
   value: label.id,
-  label: (label.icon ? `${label.icon} ` : '') + label.name,
+  label: `${label.icon ? `${label.icon} ` : ''}${label.name}`,
 })
 
 const optionList = $derived(
-  [...streamLabelList, ...createdLabelList].map((label) => toOption(label)),
+  [
+    ...streamLabelList.toSorted((a, b) => {
+      // sort by usage
+      return b.usage - a.usage
+    }),
+    ...createdLabelList,
+  ].map((label) => toOption(label)),
 )
 
 // resolve each label in the labelIdList to a label object

--- a/src/lib/core/replicache/version.ts
+++ b/src/lib/core/replicache/version.ts
@@ -1,1 +1,1 @@
-export const SCHEMA_VERSION = '2026.02.04/0'
+export const SCHEMA_VERSION = '2026.02.06/0'

--- a/src/lib/mutator/label-create.ts
+++ b/src/lib/mutator/label-create.ts
@@ -16,6 +16,7 @@ const labelCreate: LocalMutator<'label_create'> = async (context, options) => {
     color,
     icon,
     parentLabelIdList,
+    usage: 0,
   })
   await tx.set(key, value)
 }

--- a/src/lib/server/db/label/get-label-usage-list.ts
+++ b/src/lib/server/db/label/get-label-usage-list.ts
@@ -1,0 +1,49 @@
+import { errorBoundary } from '@stayradiated/error-boundary'
+import { sql } from 'kysely'
+
+import type { LabelId, UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+
+type GetLabelUsageListOptions = {
+  db: KyselyDb
+  where: {
+    userId: UserId
+    labelId: {
+      in: LabelId[]
+    }
+    point: {
+      startedAt: {
+        gte: number
+        lte: number
+      }
+    }
+  }
+}
+
+type LabelUsage = {
+  id: LabelId
+  count: number
+}
+
+const getLabelUsageList = async (
+  options: GetLabelUsageListOptions,
+): Promise<LabelUsage[] | Error> => {
+  const { db, where } = options
+
+  return errorBoundary(() => {
+    const query = db
+      .selectFrom('point')
+      .innerJoin('pointLabel', 'point.id', 'pointLabel.pointId')
+      .innerJoin('label', 'pointLabel.labelId', 'label.id')
+      .select((eb) => ['label.id', eb.fn.count<number>('point.id').as('count')])
+      .where('point.userId', '=', where.userId)
+      .where('point.startedAt', '>=', where.point.startedAt.gte)
+      .where('point.startedAt', '<', where.point.startedAt.lte)
+      .where((eb) => eb('label.id', '=', eb.fn.any(sql.val(where.labelId.in))))
+      .groupBy('label.id')
+
+    return query.execute()
+  })
+}
+
+export { getLabelUsageList }

--- a/src/lib/types.local.ts
+++ b/src/lib/types.local.ts
@@ -18,6 +18,7 @@ type LocalLabel = {
   name: string
   icon: string | undefined
   color: string | undefined
+  usage: number
   parentLabelIdList: readonly LabelId[]
 }
 


### PR DESCRIPTION
This commit introduces several changes to implement tracking of label usage within the application. 

- Updated the `PointInput.svelte` file to sort labels by usage when creating the options list.
- Increased the schema version in `version.ts` to reflect the addition of new features.
- Modified the label creation logic in `label-create.ts` to initialize the usage count to 0.
- Created a new file `get-label-usage-list.ts` to fetch label usage data from the database.
- Updated the local types definition in `types.local.ts` to include a 'usage' property for labels.
- Enhanced the `get-cvr.ts` route to include label usage data within the response.

These changes were made to provide a comprehensive view of label engagement, which can help users understand and manage their labels more effectively.