### PR TITLE
feat(label): use MultiSelect for parent selection and enable creatable labels

### DIFF
--- a/src/lib/components/LabelManager/LabelEditor.svelte
+++ b/src/lib/components/LabelManager/LabelEditor.svelte
@@ -20,6 +20,7 @@ type Props = {
 }
 
 const { store, labelId, onsubmit }: Props = $props()
+const uid = $props.id()
 
 const { _: label } = $derived(watch(store.label.get(labelId)))
 const { _: stream } = $derived(
@@ -78,13 +79,8 @@ const handleSubmit = async () => {
 {#if label}
   <div class="LabelEditor">
     <div>
-      <label>Parent
-        {#if stream?.parentId}
-          <SelectLabel {store} streamId={stream.parentId} value={parentLabelIdList} onchange={(value) => parentLabelIdList = value} />
-        {:else}
-          <p>n/a</p>
-        {/if}
-      </label>
+      <label>Name
+        <input type="text" name="name" bind:value={name} /></label>
     </div>
 
     <div>
@@ -101,11 +97,6 @@ const handleSubmit = async () => {
     </div>
 
     <div>
-      <label>Name
-        <input type="text" name="name" bind:value={name} /></label>
-    </div>
-
-    <div>
       <label>
         Color
         {#if color}
@@ -115,6 +106,21 @@ const handleSubmit = async () => {
           <button type="button" onclick={() => color =('#fff')}>Set Color</button>
         {/if}
       </label>
+    </div>
+
+    <div>
+      <label for="parent-{uid}">Parent</label>
+      {#if stream?.parentId}
+        <SelectLabel
+          id="parent-{uid}"
+          {store}
+          streamId={stream.parentId}
+          value={parentLabelIdList}
+          onchange={(value) => parentLabelIdList = value}
+        />
+      {:else}
+        <p>n/a</p>
+      {/if}
     </div>
 
     <button onclick={handleSubmit}>Save</button>

--- a/src/lib/components/Log/Line.svelte
+++ b/src/lib/components/Log/Line.svelte
@@ -31,12 +31,12 @@ const { _: labelList } = $derived(
 <div class="Line">
   {#if labelList.length > 0}
     {#each labelList as label (label.id)}
-      <span class="label" style:--color={label.color}>
+      <a class="label" style:--color={label.color} href="/label/edit/{label.id}">
         {#if label.icon}
           <Emoji native={label.icon} />
         {/if}
         {label.name}
-      </span>
+      </a>
     {/each}
   {/if}
 
@@ -59,5 +59,10 @@ const { _: labelList } = $derived(
     color: contrast-color(var(--color));
     border-radius: var(--radius-xs);
     padding: var(--size-1);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 </style>

--- a/src/lib/components/MultiSelect/MultiSelect.svelte
+++ b/src/lib/components/MultiSelect/MultiSelect.svelte
@@ -7,6 +7,8 @@ type Option = {
 }
 
 type Props = {
+  id?: string
+  isCreatable?: boolean
   autofocus?: boolean
   optionList: readonly Option[]
   selectedList: readonly Option[]
@@ -16,6 +18,8 @@ type Props = {
 }
 
 const {
+  id,
+  isCreatable = false,
   autofocus,
   optionList,
   selectedList,
@@ -97,7 +101,7 @@ const handleKeyDown = (
       const option = filteredOptionList[0]
       if (option) {
         handleAdd(option)
-      } else if (searchQuery.length > 0) {
+      } else if (isCreatable && searchQuery.length > 0) {
         handleCreate()
       }
     }
@@ -137,6 +141,7 @@ const handleRemoveAll = () => {
   </div>
 
   <input
+    {id}
     bind:this={inputEl}
     type="text"
     {placeholder}
@@ -153,7 +158,7 @@ const handleRemoveAll = () => {
           type="button"
           onmousedown={(event) => { event.stopImmediatePropagation(); event.preventDefault(); handleAdd(option) }}>{option.label}</button>
       {/each}
-      {#if searchQuery.length > 0}
+      {#if isCreatable && searchQuery.length > 0}
         <button
           type="button"
           onmousedown={(event) => { event.stopImmediatePropagation(); event.preventDefault(); handleCreate() }}>Create: {searchQuery}</button>

--- a/src/lib/components/PointManager/PointInput.svelte
+++ b/src/lib/components/PointManager/PointInput.svelte
@@ -163,6 +163,7 @@ const handleCreateLabel = (name: string) => {
   </div>
 
   <MultiSelect
+    isCreatable
     {autofocus}
     {optionList}
     {selectedList}


### PR DESCRIPTION
## Summary
Replace the old grouped <select> in the label editor with the shared MultiSelect component, add an option to create new labels inline, and make label badges in logs link to the label editor.

## Changes
- LabelEditor (LabelManager): reordered fields (Name before Parent), added a per-instance uid for accessible label/input pairing, and moved the parent picker into a dedicated block.
- SelectLabel: switched from a grouped native <select> to the MultiSelect component; now uses getLabelList (flat list) and exposes an optional id prop. onchange still emits LabelId[].
- MultiSelect: added id and isCreatable props, forward id to the input, and only show the "Create" action when isCreatable is true.
- PointInput: now passes isCreatable to MultiSelect so users can create labels inline when adding points.
- Log Line: label badges are now anchors linking to /label/edit/{label.id} (with hover underline).

## Notes / Compatibility
- UX change: SelectLabel no longer renders parent-grouped optgroups; options are a flat list. Update any tests or styles that relied on grouped structure.
- No backend migrations. The new props are optional; existing consumers should continue to work but will see the updated UI/behavior.