### PR TITLE
feat(api/internal): add /api/internal/status endpoint

### DIFF
--- a/src/routes/(app)/api/internal/status/+server.ts
+++ b/src/routes/(app)/api/internal/status/+server.ts
@@ -1,0 +1,87 @@
+import { json } from '@sveltejs/kit'
+
+import type { RequestHandler } from './$types.js'
+
+import { getDb } from '#lib/server/db/get-db.js'
+
+import { getLabelList } from '#lib/server/db/label/get-label-list.js'
+import { getActiveLineList } from '#lib/server/db/line/get-active-line-list.js'
+import { getStreamList } from '#lib/server/db/stream/get-stream-list.js'
+
+import { errorResponse } from '#lib/utils/http-error.js'
+import { promiseAllRecord } from '#lib/utils/promise-all-record.js'
+
+type StatusItem = {
+  streamName: string
+  description: string
+  startedAt: number
+  labelList: string[]
+}
+
+const GET: RequestHandler = async (event) => {
+  const { locals } = event
+  const sessionUserId = locals.session?.userId
+  if (!sessionUserId) {
+    return new Response('Must be logged in', { status: 401 })
+  }
+
+  const db = getDb()
+
+  const streamAndLineData = await promiseAllRecord({
+    streamList: getStreamList({
+      db,
+      where: {
+        userId: sessionUserId,
+      },
+    }),
+    activeLineList: getActiveLineList({
+      db,
+      where: {
+        userId: sessionUserId,
+      },
+    }),
+  })
+  if (streamAndLineData instanceof Error) {
+    return errorResponse(500, streamAndLineData)
+  }
+  const { streamList, activeLineList } = streamAndLineData
+
+  const labelIdList = activeLineList.flatMap((line) => {
+    return line.labelIdList
+  })
+  const labelList = await getLabelList({
+    db,
+    where: {
+      userId: sessionUserId,
+      labelId: { in: labelIdList },
+    },
+  })
+  if (labelList instanceof Error) {
+    return errorResponse(500, labelList)
+  }
+
+  const status: StatusItem[] = activeLineList.map((line): StatusItem => {
+    const stream = streamList.find((stream) => {
+      return stream.id === line.streamId
+    })
+
+    const lineLabelList = labelList.flatMap((label) => {
+      const isMatch = line.labelIdList.includes(label.id)
+      if (!isMatch) {
+        return []
+      }
+      return [label.icon, label.name].filter(Boolean).join(' ')
+    })
+
+    return {
+      streamName: stream?.name ?? 'Unknown',
+      description: line.description,
+      startedAt: line.startedAt,
+      labelList: lineLabelList,
+    }
+  })
+
+  return json(status)
+}
+
+export { GET }


### PR DESCRIPTION
## Summary
Add a new internal GET endpoint at /api/internal/status that returns per-active-line status for the authenticated user (stream name, description, startedAt, and a label list).

## Changes
- Add new route file src/routes/(app)/api/internal/status/+server.ts exposing a GET handler.
- Requires an authenticated session (returns 401 if no session); queries getStreamList and getActiveLineList in parallel and then fetches related labels.
- Returns an array of status items: { streamName, description, startedAt, labelList } where labels are formatted as "icon name" and joined; unknown streams fall back to "Unknown".
- Uses promiseAllRecord for parallel DB calls and errorResponse to surface DB errors as 500 responses.

## Notes
- No DB schema changes or migrations. This is a non-breaking addition providing a new internal API for consumers that need per-line runtime/status information.