### PR TITLE
fix(service-worker): hide update bar by default

### DIFF
--- a/src/lib/components/ServiceWorker.svelte
+++ b/src/lib/components/ServiceWorker.svelte
@@ -3,7 +3,7 @@ import { onMount } from 'svelte'
 
 import { registerServiceWorker } from '../../service-worker.init.js'
 
-let showUpdate = $state(true)
+let showUpdate = $state(false)
 let applyUpdate = $state<() => void>()
 
 onMount(async () => {


### PR DESCRIPTION
## Summary
Hide the service worker "update available" bar by default to prevent the update banner from appearing on page load when no update is present.

## Changes
- Set showUpdate initial value to false in src/lib/components/ServiceWorker.svelte
- Leave applyUpdate and service worker registration logic unchanged
- Prevents the update UI from being shown erroneously on initial render; the banner will only appear when the app sets showUpdate to true (e.g., in response to a service worker event)

No migrations, config changes, or other functional changes.