### PR TITLE
feat(api): add API bearer token support

### DIFF
--- a/migrations/committed/000015.sql
+++ b/migrations/committed/000015.sql
@@ -1,0 +1,12 @@
+--! Previous: sha1:0f38d16022fbda9fc9c07a450c4d134e579f359b
+--! Hash: sha1:efea0d5cd80103ae19a7643636bc186d5458881f
+
+--
+-- Add api_token_hash column to user table
+--
+
+ALTER TABLE public.user
+  DROP COLUMN IF EXISTS api_token_hash;
+
+ALTER TABLE public.user
+  ADD COLUMN api_token_hash BYTEA; /* nullable */

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -263,6 +263,7 @@ CREATE TABLE public."user" (
     updated_at bigint NOT NULL,
     email text NOT NULL,
     slack_token text,
+    api_token_hash bytea,
     CONSTRAINT "user:check(email)" CHECK ((email = lower(email)))
 );
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "kanel-zod": "1.7.0",
     "knip": "5.86.0",
     "kysely": "0.28.12",
-    "svelte": "5.53.11",
+    "svelte": "5.53.12",
     "svelte-check": "4.4.5",
     "test-fixture-factory": "2.1.0",
     "type-fest": "5.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         version: 1.1.0(@stayradiated/error-boundary@4.3.0)(p-map@7.0.4)
       '@sveltelaunch/svelte-5-email':
         specifier: 0.0.11
-        version: 0.0.11(svelte@5.53.11)
+        version: 0.0.11(svelte@5.53.12)
       ai:
         specifier: 6.0.116
         version: 6.0.116(zod@4.3.6)
@@ -90,7 +90,7 @@ importers:
         version: 0.1.5
       svelte-awesome-color-picker:
         specifier: 4.1.1
-        version: 4.1.1(svelte@5.53.11)
+        version: 4.1.1(svelte@5.53.12)
       websocket-ts:
         specifier: 2.2.1
         version: 2.2.1
@@ -112,13 +112,13 @@ importers:
         version: 4.3.0
       '@sveltejs/adapter-node':
         specifier: 5.5.4
-        version: 5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))
+        version: 5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: 2.55.0
-        version: 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+        version: 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.0.0
-        version: 7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+        version: 7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
       '@types/node':
         specifier: 25.5.0
         version: 25.5.0
@@ -136,7 +136,7 @@ importers:
         version: 10.0.3(jiti@2.6.1)
       eslint-plugin-svelte:
         specifier: 3.15.2
-        version: 3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.11)
+        version: 3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.12)
       id128:
         specifier: 1.6.6
         version: 1.6.6
@@ -156,11 +156,11 @@ importers:
         specifier: 0.28.12
         version: 0.28.12
       svelte:
-        specifier: 5.53.11
-        version: 5.53.11
+        specifier: 5.53.12
+        version: 5.53.12
       svelte-check:
         specifier: 4.4.5
-        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.11)(typescript@5.9.3)
+        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3)
       test-fixture-factory:
         specifier: 2.1.0
         version: 2.1.0
@@ -2625,8 +2625,8 @@ packages:
       svelte:
         optional: true
 
-  svelte@5.53.11:
-    resolution: {integrity: sha512-GYmqRjRhJYLQBonfdfGAt28gkfWEShrtXKGXcFGneXi502aBE+I1dJcs/YQriByvP6xqXRz/OdBGC6tfvUQHyQ==}
+  svelte@5.53.12:
+    resolution: {integrity: sha512-4x/uk4rQe/d7RhfvS8wemTfNjQ0bJbKvamIzRBfTe2eHHjzBZ7PZicUQrC2ryj83xxEacfA1zHKd1ephD1tAxA==}
     engines: {node: '>=18'}
 
   svix@1.84.1:
@@ -3658,19 +3658,19 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@sveltejs/kit': 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+      '@sveltejs/kit': 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
       rollup: 4.59.0
 
-  '@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))':
+  '@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -3681,26 +3681,26 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
-      svelte: 5.53.11
+      svelte: 5.53.12
       vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))':
+  '@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.53.11
+      svelte: 5.53.12
       vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
       vitefu: 1.1.2(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
 
-  '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.53.11)':
+  '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.53.12)':
     dependencies:
       html-to-text: 9.0.5
       pretty: 2.0.0
-      svelte: 5.53.11
+      svelte: 5.53.12
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -4184,7 +4184,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-svelte@3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.11):
+  eslint-plugin-svelte@3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.12):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.6.1))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4196,9 +4196,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.8)
       postcss-safe-parser: 7.0.1(postcss@8.5.8)
       semver: 7.7.4
-      svelte-eslint-parser: 1.6.0(svelte@5.53.11)
+      svelte-eslint-parser: 1.6.0(svelte@5.53.12)
     optionalDependencies:
-      svelte: 5.53.11
+      svelte: 5.53.12
     transitivePeerDependencies:
       - ts-node
 
@@ -5225,29 +5225,29 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-awesome-color-picker@4.1.1(svelte@5.53.11):
+  svelte-awesome-color-picker@4.1.1(svelte@5.53.12):
     dependencies:
       colord: 2.9.3
-      svelte: 5.53.11
-      svelte-awesome-slider: 2.0.0(svelte@5.53.11)
+      svelte: 5.53.12
+      svelte-awesome-slider: 2.0.0(svelte@5.53.12)
 
-  svelte-awesome-slider@2.0.0(svelte@5.53.11):
+  svelte-awesome-slider@2.0.0(svelte@5.53.12):
     dependencies:
-      svelte: 5.53.11
+      svelte: 5.53.12
 
-  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.53.11)(typescript@5.9.3):
+  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.53.11
+      svelte: 5.53.12
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.6.0(svelte@5.53.11):
+  svelte-eslint-parser@1.6.0(svelte@5.53.12):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -5257,9 +5257,9 @@ snapshots:
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
     optionalDependencies:
-      svelte: 5.53.11
+      svelte: 5.53.12
 
-  svelte@5.53.11:
+  svelte@5.53.12:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -36,7 +36,8 @@ export const handle: Handle = async ({ event, resolve }) => {
   // do not require a cookie session when querying these exact paths
   if (
     event.route.id === '/login' ||
-    event.route.id === '/login/verify/[emailVerificationId]'
+    event.route.id === '/login/verify/[emailVerificationId]' ||
+    event.route.id?.startsWith('/(app)/api/v1/') === true
   ) {
     return resolve(event)
   }

--- a/src/lib/__generated__/kanel/public/User.ts
+++ b/src/lib/__generated__/kanel/public/User.ts
@@ -21,6 +21,8 @@ export default interface UserTable {
   email: ColumnType<string, string, string>;
 
   slackToken: ColumnType<string | null, string | null, string | null>;
+
+  apiTokenHash: ColumnType<Uint8Array | null, Uint8Array | null, Uint8Array | null>;
 }
 
 export type User = Selectable<UserTable>;
@@ -40,6 +42,7 @@ export const user = z.object({
   updatedAt: z.number(),
   email: z.string(),
   slackToken: z.string().nullable().nullable(),
+  apiTokenHash: z.instanceof(Uint8Array).nullable().nullable(),
 });
 
 export const userInitializer = z.object({
@@ -51,6 +54,7 @@ export const userInitializer = z.object({
   updatedAt: z.number(),
   email: z.string(),
   slackToken: z.string().nullable().optional().nullable(),
+  apiTokenHash: z.instanceof(Uint8Array).nullable().optional().nullable(),
 });
 
 export const userMutator = z.object({
@@ -62,4 +66,5 @@ export const userMutator = z.object({
   updatedAt: z.number().optional(),
   email: z.string().optional(),
   slackToken: z.string().nullable().optional().nullable(),
+  apiTokenHash: z.instanceof(Uint8Array).nullable().optional().nullable(),
 });

--- a/src/lib/server/api-token/api-bearer-token.ts
+++ b/src/lib/server/api-token/api-bearer-token.ts
@@ -1,0 +1,90 @@
+import type { UserId } from '#lib/ids.js'
+
+const API_TOKEN_LENGTH = 32
+const AUTH_TOKEN_SEPARATOR = '.'
+const AUTH_TOKEN_PREFIX_V1 = 'aeon'
+type ApiBearerToken =
+  | {
+      version: 0
+      userId: UserId
+      value: string
+    }
+  | {
+      version: 1
+      userId: UserId
+      value: string
+    }
+/*
+ * generate a secure random API token
+ * this must be browser compatible, as we generate the token locally
+ */
+const genApiBearerToken = (userId: UserId): ApiBearerToken => {
+  // Create an array with cryptographically secure random values
+  const tokenBytes = new Uint8Array(API_TOKEN_LENGTH)
+  crypto.getRandomValues(tokenBytes)
+  const value = Buffer.from(tokenBytes).toString('base64url')
+  return {
+    version: 1,
+    userId,
+    value,
+  }
+}
+const marshalApiBearerToken = (authToken: ApiBearerToken): string | Error => {
+  const { version } = authToken
+  switch (version) {
+    case 0: {
+      return [authToken.userId, authToken.value].join(AUTH_TOKEN_SEPARATOR)
+    }
+    case 1: {
+      return [AUTH_TOKEN_PREFIX_V1, authToken.userId, authToken.value].join(
+        AUTH_TOKEN_SEPARATOR,
+      )
+    }
+    default: {
+      version satisfies never
+      return new Error(`Unknown ApiBearerToken version: '${version}'`)
+    }
+  }
+}
+const unmarshalApiBearerToken = (input: string): ApiBearerToken | Error => {
+  const parts = input.split(AUTH_TOKEN_SEPARATOR)
+  const prefix = parts.at(0)
+  if (prefix === AUTH_TOKEN_PREFIX_V1) {
+    if (parts.length !== 3) {
+      return new Error('Invalid ApiBearerToken')
+    }
+    const userId = parts.at(1)
+    if (!userId || userId.trim().length === 0) {
+      return new Error('Invalid ApiBearerToken (invalid userId)')
+    }
+    const value = parts.at(2)
+    if (!value || value.trim().length === 0) {
+      return new Error('Invalid ApiBearerToken (invalid value)')
+    }
+    return {
+      version: 1,
+      userId: userId as UserId,
+      value,
+    }
+  }
+  if (parts.length !== 2) {
+    return new Error('Invalid ApiBearerToken')
+  }
+  const userId = prefix
+  if (!userId || userId.trim().length === 0) {
+    return new Error('Invalid ApiBearerToken (invalid userId)')
+  }
+  const value = parts.at(1)
+  if (!value || value.trim().length === 0) {
+    return new Error('Invalid ApiBearerToken (invalid value)')
+  }
+  return {
+    version: 0,
+    userId: userId as UserId,
+    value,
+  }
+}
+
+export type { ApiBearerToken }
+
+export { genApiBearerToken, marshalApiBearerToken, unmarshalApiBearerToken }

--- a/src/lib/server/api-token/get-api-session.ts
+++ b/src/lib/server/api-token/get-api-session.ts
@@ -1,0 +1,78 @@
+import type { UserId } from '#lib/ids.js'
+import type { KyselyDb } from '#lib/server/db/types.js'
+
+import { getAeonApiKeySecret } from '#lib/server/env.js'
+
+import { getUser } from '#lib/server/db/user/get-user.js'
+
+import { unmarshalApiBearerToken } from './api-bearer-token.js'
+import { verifyTokenWithHash } from './hash-token.js'
+
+class AuthenticationError extends Error {}
+
+type ApiSession = {
+  sessionUserId: UserId
+}
+
+type GetApiSessionOptions = {
+  db: KyselyDb
+  request: Request
+}
+
+const getApiSession = async (
+  options: GetApiSessionOptions,
+): Promise<ApiSession | AuthenticationError | Error> => {
+  const { db, request } = options
+
+  const authHeader = request.headers.get('authorization')
+  if (!authHeader) {
+    return new AuthenticationError('Missing Authorization Header')
+  }
+
+  const authToken = authHeader.match(/^Bearer (.+)$/i)?.at(1)
+  if (!authToken) {
+    return new AuthenticationError('Invalid Authorization Token')
+  }
+
+  const apiBearerToken = unmarshalApiBearerToken(authToken)
+  if (apiBearerToken instanceof Error) {
+    return new AuthenticationError('Invalid Authorization Token', {
+      cause: apiBearerToken,
+    })
+  }
+
+  const { userId } = apiBearerToken
+
+  const user = await getUser({ db, where: { userId } })
+  if (user instanceof Error) {
+    return new AuthenticationError('Invalid Authorization Token', {
+      cause: user,
+    })
+  }
+  if (!user) {
+    return new AuthenticationError('Invalid Authorization Token', {
+      cause: new Error(`Could not find user with ID: ${userId}`),
+    })
+  }
+  if (!user.apiTokenHash) {
+    return new AuthenticationError('Invalid Authorization Token', {
+      cause: new Error(`User ${userId} does not have an api token hash`),
+    })
+  }
+
+  if (
+    !verifyTokenWithHash({
+      secret: getAeonApiKeySecret(),
+      token: authToken,
+      hash: user.apiTokenHash,
+    })
+  ) {
+    return new AuthenticationError('Invalid Authorization Token')
+  }
+
+  return {
+    sessionUserId: user.id,
+  }
+}
+
+export { AuthenticationError, getApiSession }

--- a/src/lib/server/api-token/hash-token.ts
+++ b/src/lib/server/api-token/hash-token.ts
@@ -1,0 +1,22 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+type HashTokenOptions = {
+  secret: string
+  token: string
+}
+const hashToken = (options: HashTokenOptions): Uint8Array => {
+  const { secret, token } = options
+  return createHmac('sha256', secret).update(token).digest()
+}
+
+type VerifyTokenWithHashOptions = {
+  secret: string
+  token: string
+  hash: Uint8Array
+}
+const verifyTokenWithHash = (options: VerifyTokenWithHashOptions): boolean => {
+  const { secret, token, hash } = options
+  return timingSafeEqual(hashToken({ secret, token }), hash)
+}
+
+export { hashToken, verifyTokenWithHash }

--- a/src/lib/server/db/user/update-user.ts
+++ b/src/lib/server/db/user/update-user.ts
@@ -10,6 +10,7 @@ type UpdateUserOptions = {
   }
   set: {
     slackToken?: string | null
+    apiTokenHash?: Uint8Array | null
   }
   now?: number
 }

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -5,6 +5,13 @@ import { createEnvGetter } from '#lib/utils/create-env-getter.js'
 import { env as privateEnv } from '$env/dynamic/private'
 
 const getDatabaseUrl = createEnvGetter(privateEnv, 'DATABASE_URL', z.url())
+
+const getAeonApiKeySecret = createEnvGetter(
+  privateEnv,
+  'AEON_API_KEY_SECRET',
+  z.string(),
+)
+
 const getResendApiKey = createEnvGetter(
   privateEnv,
   'RESEND_API_KEY',
@@ -17,4 +24,4 @@ const getOpenAIApiKey = createEnvGetter(
   z.string(),
 )
 
-export { getDatabaseUrl, getOpenAIApiKey, getResendApiKey }
+export { getAeonApiKeySecret, getDatabaseUrl, getOpenAIApiKey, getResendApiKey }

--- a/src/lib/server/snapshot/schema.ts
+++ b/src/lib/server/snapshot/schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { $Label, $Point, $Stream, $User } from '#lib/schema.js'
 
 const $Snapshot = z.object({
-  user: z.array($User.omit({ id: true, email: true })),
+  user: z.array($User.omit({ id: true, email: true, apiTokenHash: true })),
   stream: z.array($Stream.omit({ userId: true })),
   label: z.array($Label.omit({ userId: true })),
   point: z.array($Point.omit({ userId: true })),

--- a/src/lib/test/use-user.ts
+++ b/src/lib/test/use-user.ts
@@ -30,6 +30,7 @@ const userFactory = createFactory<User>('User')
         stravaClientSecret: null,
         stravaSession: null,
         slackToken: null,
+        apiTokenHash: null,
       },
     })
     assertOk(user)

--- a/src/routes/(app)/api/v1/status/+server.ts
+++ b/src/routes/(app)/api/v1/status/+server.ts
@@ -1,4 +1,4 @@
-import { json } from '@sveltejs/kit'
+import { error, json } from '@sveltejs/kit'
 
 import type { RequestHandler } from './$types.js'
 
@@ -7,6 +7,11 @@ import { getDb } from '#lib/server/db/get-db.js'
 import { getLabelList } from '#lib/server/db/label/get-label-list.js'
 import { getActiveLineList } from '#lib/server/db/line/get-active-line-list.js'
 import { getStreamList } from '#lib/server/db/stream/get-stream-list.js'
+
+import {
+  AuthenticationError,
+  getApiSession,
+} from '#lib/server/api-token/get-api-session.js'
 
 import { errorResponse } from '#lib/utils/http-error.js'
 import { promiseAllRecord } from '#lib/utils/promise-all-record.js'
@@ -19,13 +24,19 @@ type StatusItem = {
 }
 
 const GET: RequestHandler = async (event) => {
-  const { locals } = event
-  const sessionUserId = locals.session?.userId
-  if (!sessionUserId) {
-    return new Response('Must be logged in', { status: 401 })
-  }
+  const { request } = event
 
   const db = getDb()
+
+  const session = await getApiSession({ db, request })
+  if (session instanceof AuthenticationError) {
+    throw error(401, session.message)
+  }
+  if (session instanceof Error) {
+    throw session
+  }
+
+  const { sessionUserId } = session
 
   const streamAndLineData = await promiseAllRecord({
     streamList: getStreamList({

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -14,8 +14,12 @@ import MetaTaskProgress from '#lib/components/MetaTask/MetaTaskProgress.svelte'
 import StatusManager from '#lib/components/Status/StatusManager.svelte'
 import StreamManager from '#lib/components/StreamManager/StreamManager.svelte'
 
+import { setApiToken } from './set-api-token.remote.js'
+
 const { data }: PageProps = $props()
 const { store } = $derived(data)
+
+let apiToken = $state<string>()
 
 import { openFilePicker } from '#lib/utils/open-file-picker.js'
 
@@ -111,6 +115,17 @@ const handleAssignLabelParent = async () => {
     <p>Scan existing labels and associate them with the correct parent.</p>
     <button onclick={handleAssignLabelParent}>Assign Label Parent</button>
     <MetaTaskProgress {store} name="fixup-all-label-parents" />
+  </section>
+
+  <section>
+    <h2>API Access</h2>
+    {#if apiToken}
+      <pre><code>{apiToken}</code></pre>
+      <p>Copy this token, it will be hidden when you next view this page!</p>
+    {:else}
+      <pre><code>aeon.**************************.*******************************************</code></pre>
+      <button onclick={async () => { apiToken = await setApiToken() }}>Reset API Token</button>
+    {/if}
   </section>
 
   <section>

--- a/src/routes/(app)/settings/set-api-token.remote.ts
+++ b/src/routes/(app)/settings/set-api-token.remote.ts
@@ -1,0 +1,46 @@
+import { error } from '@sveltejs/kit'
+
+import { command, getRequestEvent } from '$app/server'
+
+import { getAeonApiKeySecret } from '#lib/server/env.js'
+
+import { getDb } from '#lib/server/db/get-db.js'
+
+import { updateUser } from '#lib/server/db/user/update-user.js'
+
+import {
+  genApiBearerToken,
+  marshalApiBearerToken,
+} from '#lib/server/api-token/api-bearer-token.js'
+import { hashToken } from '#lib/server/api-token/hash-token.js'
+
+const setApiToken = command(async () => {
+  const { locals } = getRequestEvent()
+
+  const sessionUserId = locals.session?.userId
+  if (!sessionUserId) {
+    throw error(402, 'Must be logged in')
+  }
+
+  const db = getDb()
+
+  const apiBearerToken = genApiBearerToken(sessionUserId)
+  const token = marshalApiBearerToken(apiBearerToken)
+  if (token instanceof Error) {
+    return error(500, token)
+  }
+
+  await updateUser({
+    db,
+    where: {
+      userId: sessionUserId,
+    },
+    set: {
+      apiTokenHash: hashToken({ secret: getAeonApiKeySecret(), token }),
+    },
+  })
+
+  return token
+})
+
+export { setApiToken }

--- a/src/routes/login/verify/[emailVerificationId]/+page.server.ts
+++ b/src/routes/login/verify/[emailVerificationId]/+page.server.ts
@@ -109,6 +109,7 @@ const actions = {
           stravaClientSecret: null,
           stravaSession: null,
           slackToken: null,
+          apiTokenHash: null,
         },
       })
       if (user instanceof Error) {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -23,6 +23,10 @@ const config = {
       // see src/service-worker.init.ts
       register: false,
     },
+
+    experimental: {
+      remoteFunctions: true,
+    },
   },
 }
 


### PR DESCRIPTION
## Summary
Introduce API bearer token authentication: generate, hash, store, and verify per-user API tokens; expose a settings UI to create/reset a token; and allow API routes to authenticate via Bearer tokens instead of cookie sessions.

## Changes
- Database & schema
  - Add migration to create user.api_token_hash (BYTEA) and update schema/types/fixtures/snapshots accordingly.
  - Generated Kanel types and test factories/snapshots updated to include apiTokenHash (nullable).

- API token core
  - New utilities: genApiBearerToken, marshal/unmarshal token format (v1 uses prefix `aeon`), hashToken (HMAC-SHA256) and verifyTokenWithHash (timing-safe compare).
  - getApiSession reads Bearer header, verifies token against stored hash, and returns sessionUserId or AuthenticationError.

- Routes & UI
  - Settings page: add API Access section with a remote command to generate/reset a token and show it once to the user.
  - Status API moved/renamed to /(app)/api/v1/status and now authenticates via getApiSession (Bearer) instead of cookie session.
  - hooks updated to allow requests under /(app)/api/v1/ to bypass cookie-session requirement.

- Env & config
  - Add AEON_API_KEY_SECRET env getter (required) used to HMAC tokens.
  - Enable experimental.remoteFunctions in svelte.config.js.

- Misc
  - Dependency bump: svelte 5.53.11 -> 5.53.12 and lockfile updates.

## Breaking changes / migration notes
- Run the new DB migration to add user.api_token_hash before using API tokens.
- AEON_API_KEY_SECRET must be set in the environment; it is used to HMAC tokens.
- Tokens are stored only as HMAC hashes; the plaintext token is shown once at creation/reset and cannot be recovered later. Keep a copy after generation.
- Remote functions experimental flag enabled — be aware this may affect build/runtime behavior.

No other behavioral changes to existing cookie-session auth flows aside from the added API bearer auth path.