### PR TITLE
feat(heatgrid): improve heat map calendar

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4311,7 +4311,7 @@ snapshots:
   extract-pg-schema@5.8.1(@electric-sql/pglite@0.3.15):
     dependencies:
       knex: 3.1.0(pg@8.17.2)
-      knex-pglite: 0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.17.2))
+      knex-pglite: 0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.20.0))
       pg: 8.17.2
       pg-query-emscripten: 5.1.0
       ramda: 0.31.3
@@ -4633,7 +4633,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knex-pglite@0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.17.2)):
+  knex-pglite@0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.20.0)):
     dependencies:
       '@electric-sql/pglite': 0.3.15
       knex: 3.1.0(pg@8.17.2)

--- a/src/lib/components/HeatGrid/HeatGrid.svelte
+++ b/src/lib/components/HeatGrid/HeatGrid.svelte
@@ -10,26 +10,52 @@ type Props = {
 const { grid }: Props = $props()
 </script>
 
-<div class="HeatGrid" style:--height={grid.width} style:--width={grid.rows.length}>
-  {#each grid.rows as row, rowIndex (rowIndex)}
-    {#each row.cells as cell, cellIndex (cellIndex)}
-      <div class="cell" style:--color={getHeatmapColor((cell?.durationMs ?? 0) / 1000 / 60)}></div>
+<div
+  class="HeatGrid"
+  style:--rows={grid.width}
+  style:--cols={grid.rows.length}>
+  <div class="grid">
+    {#each grid.rows as row, rowIndex (rowIndex)}
+      {#each row.cells as cell, cellIndex (cellIndex)}
+        <div
+          class="cell"
+          class:placeholder={typeof cell === 'undefined'}
+          style:--color={getHeatmapColor((cell?.durationMs ?? 0) / 1000 / 60)}></div>
+      {/each}
     {/each}
-  {/each}
+  </div>
 </div>
 
 <style>
   .HeatGrid {
+    container-type: inline-size;
+  }
+
+  .grid {
+    --gap: var(--size-px);
+    --cell-size: calc((100cqw - (var(--cols) - 1) * var(--gap) - 2 * var(--gap)) / var(--cols));
+
     display: grid;
     grid-auto-flow: column;
-    grid-template-columns: repeat(var(--width), 1fr);
-    grid-template-rows: repeat(var(--height), var(--size-3));
-    gap: var(--size-px);
+    grid-template-columns: repeat(var(--cols), var(--cell-size));
+    grid-template-rows: repeat(var(--rows), var(--cell-size));
+
+    /* draw grid border by adding padding and setting a background colour */
+    gap: var(--gap);
+    padding: var(--gap);
     background: var(--color-grey-100);
-    padding: var(--size-px);
   }
 
   .cell {
     background: var(--color);
+  }
+
+  .cell.placeholder {
+    background:
+      repeating-linear-gradient(
+        135deg,
+        var(--color-grey-50) 0 2px,
+        var(--color-grey-400) 2px 4px
+      );
   }
 </style>

--- a/src/lib/components/LabelPage/LabelHeatGrid.svelte
+++ b/src/lib/components/LabelPage/LabelHeatGrid.svelte
@@ -71,7 +71,6 @@ const grid = $derived.by(() => {
 </script>
 
 <h4>{year}</h4>
-
 <HeatGrid {grid} />
 
 <style>

--- a/src/lib/core/select/get-daily-duration-list.ts
+++ b/src/lib/core/select/get-daily-duration-list.ts
@@ -4,8 +4,6 @@ import { computed } from 'signia'
 import type { LabelId, StreamId } from '#lib/ids.js'
 import type { CalendarDate } from '#lib/utils/calendar-date.js'
 
-import { calcDuration } from '#lib/core/shape/calc-duration.js'
-
 import * as calDateFns from '#lib/utils/calendar-date.js'
 import { createSelector } from '#lib/utils/selector.js'
 
@@ -47,14 +45,28 @@ const getDailyDurationList = createSelector(
       const entryRecord: Record<CalendarDate, DailyEntry> = {}
 
       for (const line of lineList) {
-        const { startedAt } = line
-        const timeZone = getTimeZone(store, startedAt).value
-        const date = calDateFns.fromInstant(startedAt, tz(timeZone))
+        const { startedAt, stoppedAt } = line
 
-        entryRecord[date] ??= { date, durationMs: 0 }
-        const entry = entryRecord[date]
+        // TODO: handle timezone changes during this time
+        const timeZoneName = getTimeZone(store, startedAt).value
+        const timeZone = tz(timeZoneName)
 
-        entry.durationMs += calcDuration(line, now)
+        for (const date of calDateFns.eachDayOfInterval({
+          start: calDateFns.fromInstant(startedAt, timeZone),
+          end: calDateFns.fromInstant(stoppedAt ?? now, timeZone),
+        })) {
+          const startOfDay = calDateFns.toInstant(date, timeZone)
+          const endOfDay = startOfDay + calDateFns.MS_PER_DAY
+          const startInstant = Math.max(startedAt, startOfDay)
+          const stopInstant = Math.min(stoppedAt ?? now, endOfDay)
+          const durationMs = stopInstant - startInstant
+
+          if (entryRecord[date]) {
+            entryRecord[date].durationMs += durationMs
+          } else {
+            entryRecord[date] = { date, durationMs }
+          }
+        }
       }
 
       return Object.values(entryRecord).sort((a, b) => {

--- a/src/lib/core/shape/calc-duration.ts
+++ b/src/lib/core/shape/calc-duration.ts
@@ -1,6 +1,9 @@
 import type { Line } from './types.js'
 
-const calcDuration = (line: Line, now: number): number => {
+const calcDuration = (
+  line: Pick<Line, 'durationMs' | 'startedAt'>,
+  now: number,
+): number => {
   return line.durationMs ? line.durationMs : now - line.startedAt
 }
 

--- a/src/lib/utils/calendar-date.ts
+++ b/src/lib/utils/calendar-date.ts
@@ -117,6 +117,7 @@ export {
   getMonth,
   getYear,
   isWeekend,
+  MS_PER_DAY,
   subDays,
   toEarliestInstant,
   toInstant,


### PR DESCRIPTION
## Summary
Improve the heatmap calendar UI and make daily-duration aggregation accurate across multi-day entries.

## Changes
- UI: rewrite HeatGrid layout to use a CSS grid with explicit rows/cols, responsive cell sizing, padding border, and a placeholder pattern for missing cells; add container-type for better sizing behavior.
- Logic: rewrite get-daily-duration-list to split a line that spans multiple days into per-day durations (uses eachDayOfInterval and sums overlaps per day). Respects the timezone at the line start (TODO: does not handle timezone changes during an interval).
- Core: narrow calc-duration's parameter type (now accepts only startedAt/durationMs) and keep fallback to now; export MS_PER_DAY from calendar-date utilities.
- Misc: minor whitespace cleanup in LabelHeatGrid; pnpm-lock updated to reflect pg 8.20.0 reference in knex-pglite snapshot.

## Breaking changes / notes
- Data aggregation: daily totals can change for records that span multiple days (they are now distributed across the days). This may affect analytics or existing heatmap counts.
- UI: heatmap appearance, spacing, and placeholder visuals changed; container-type uses modern CSS and may behave differently in older browsers.
- Timezones: current logic uses the start instant's timezone and does not handle timezone changes during an interval (documented TODO).

No config migrations required.