### PR TITLE
feat(label): add weekly chart to LabelPage and update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "version": "1.0.0",
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.32.1",
   "engines": {
     "node": ">=24.0.0"
   },
@@ -62,7 +62,7 @@
     "kanel-zod": "1.7.0",
     "knip": "5.86.0",
     "kysely": "0.28.12",
-    "svelte": "5.53.12",
+    "svelte": "5.53.11",
     "svelte-check": "4.4.5",
     "test-fixture-factory": "2.1.0",
     "type-fest": "5.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         version: 1.1.0(@stayradiated/error-boundary@4.3.0)(p-map@7.0.4)
       '@sveltelaunch/svelte-5-email':
         specifier: 0.0.11
-        version: 0.0.11(svelte@5.53.12)
+        version: 0.0.11(svelte@5.53.11)
       ai:
         specifier: 6.0.116
         version: 6.0.116(zod@4.3.6)
@@ -90,7 +90,7 @@ importers:
         version: 0.1.5
       svelte-awesome-color-picker:
         specifier: 4.1.1
-        version: 4.1.1(svelte@5.53.12)
+        version: 4.1.1(svelte@5.53.11)
       websocket-ts:
         specifier: 2.2.1
         version: 2.2.1
@@ -106,19 +106,19 @@ importers:
         version: 2.4.7
       '@roughapp/replimock':
         specifier: 15.3.0
-        version: 15.3.0(@electric-sql/pglite@0.3.15)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)(zod@4.3.6)
+        version: 15.3.0(@electric-sql/pglite@0.3.16)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)(zod@4.3.6)
       '@stayradiated/error-boundary':
         specifier: 4.3.0
         version: 4.3.0
       '@sveltejs/adapter-node':
         specifier: 5.5.4
-        version: 5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))
+        version: 5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: 2.55.0
-        version: 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+        version: 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.0.0
-        version: 7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+        version: 7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
       '@types/node':
         specifier: 25.5.0
         version: 25.5.0
@@ -130,19 +130,19 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: 4.1.0
-        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))
       eslint:
         specifier: 10.0.3
         version: 10.0.3(jiti@2.6.1)
       eslint-plugin-svelte:
         specifier: 3.15.2
-        version: 3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.12)
+        version: 3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.11)
       id128:
         specifier: 1.6.6
         version: 1.6.6
       kanel:
         specifier: 3.16.1
-        version: 3.16.1(@electric-sql/pglite@0.3.15)
+        version: 3.16.1(@electric-sql/pglite@0.3.16)
       kanel-kysely:
         specifier: 0.8.0
         version: 0.8.0
@@ -156,11 +156,11 @@ importers:
         specifier: 0.28.12
         version: 0.28.12
       svelte:
-        specifier: 5.53.12
-        version: 5.53.12
+        specifier: 5.53.11
+        version: 5.53.11
       svelte-check:
         specifier: 4.4.5
-        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3)
+        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.11)(typescript@5.9.3)
       test-fixture-factory:
         specifier: 2.1.0
         version: 2.1.0
@@ -175,10 +175,10 @@ importers:
         version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 8.0.0
-        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
+        version: 8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
 
 packages:
 
@@ -251,24 +251,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.7':
     resolution: {integrity: sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.7':
     resolution: {integrity: sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.7':
     resolution: {integrity: sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.7':
     resolution: {integrity: sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==}
@@ -288,8 +292,8 @@ packages:
   '@date-fns/utc@2.1.1':
     resolution: {integrity: sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==}
 
-  '@electric-sql/pglite@0.3.15':
-    resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
+  '@electric-sql/pglite@0.3.16':
+    resolution: {integrity: sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -302,162 +306,6 @@ packages:
 
   '@emoji-mart/data@1.2.1':
     resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
-
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -587,24 +435,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-arm64-musl@2.0.2':
     resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-linux-x64-gnu@2.0.2':
     resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-x64-musl@2.0.2':
     resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-wasm32-wasi@2.0.2':
     resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
@@ -710,41 +562,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -824,36 +684,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
@@ -951,66 +817,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1545,11 +1424,6 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2057,24 +1931,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2625,8 +2503,8 @@ packages:
       svelte:
         optional: true
 
-  svelte@5.53.12:
-    resolution: {integrity: sha512-4x/uk4rQe/d7RhfvS8wemTfNjQ0bJbKvamIzRBfTe2eHHjzBZ7PZicUQrC2ryj83xxEacfA1zHKd1ephD1tAxA==}
+  svelte@5.53.11:
+    resolution: {integrity: sha512-GYmqRjRhJYLQBonfdfGAt28gkfWEShrtXKGXcFGneXi502aBE+I1dJcs/YQriByvP6xqXRz/OdBGC6tfvUQHyQ==}
     engines: {node: '>=18'}
 
   svix@1.84.1:
@@ -3056,7 +2934,7 @@ snapshots:
 
   '@date-fns/utc@2.1.1': {}
 
-  '@electric-sql/pglite@0.3.15': {}
+  '@electric-sql/pglite@0.3.16': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -3075,84 +2953,6 @@ snapshots:
     optional: true
 
   '@emoji-mart/data@1.2.1': {}
-
-  '@esbuild/aix-ppc64@0.27.3':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/android-arm@0.27.3':
-    optional: true
-
-  '@esbuild/android-x64@0.27.3':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.3':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.3':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.3':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.3':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.3':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.3':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.3':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.3':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.3':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.3':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.3':
-    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.0.3(jiti@2.6.1))':
     dependencies:
@@ -3583,10 +3383,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@roughapp/replimock@15.3.0(@electric-sql/pglite@0.3.15)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)(zod@4.3.6)':
+  '@roughapp/replimock@15.3.0(@electric-sql/pglite@0.3.16)(replicache@15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       replicache: 15.3.0(patch_hash=498395e484bf9178518bdeda1c5a7b841fa1933e1548c2a35c43da20b84b90a9)
-      tinybase: 7.3.2(@electric-sql/pglite@0.3.15)(ws@8.19.0)(zod@4.3.6)
+      tinybase: 7.3.2(@electric-sql/pglite@0.3.16)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@automerge/automerge-repo'
       - '@cloudflare/workers-types'
@@ -3658,19 +3458,19 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@sveltejs/kit': 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+      '@sveltejs/kit': 2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
       rollup: 4.59.0
 
-  '@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))':
+  '@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))(svelte@5.53.11)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -3681,26 +3481,26 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
-      svelte: 5.53.12
-      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
+      svelte: 5.53.11
+      vite: 8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.12)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))':
+  '@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.11)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.53.12
-      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+      svelte: 5.53.11
+      vite: 8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+      vitefu: 1.1.2(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
 
-  '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.53.12)':
+  '@sveltelaunch/svelte-5-email@0.0.11(svelte@5.53.11)':
     dependencies:
       html-to-text: 9.0.5
       pretty: 2.0.0
-      svelte: 5.53.12
+      svelte: 5.53.11
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -3839,7 +3639,7 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -3851,7 +3651,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -3862,13 +3662,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -4150,41 +3950,11 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.27.3:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
-    optional: true
-
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-svelte@3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.12):
+  eslint-plugin-svelte@3.15.2(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.11):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.6.1))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4196,9 +3966,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.8)
       postcss-safe-parser: 7.0.1(postcss@8.5.8)
       semver: 7.7.4
-      svelte-eslint-parser: 1.6.0(svelte@5.53.12)
+      svelte-eslint-parser: 1.6.0(svelte@5.53.11)
     optionalDependencies:
-      svelte: 5.53.12
+      svelte: 5.53.11
     transitivePeerDependencies:
       - ts-node
 
@@ -4308,10 +4078,10 @@ snapshots:
     dependencies:
       is-extendable: 0.1.1
 
-  extract-pg-schema@5.8.1(@electric-sql/pglite@0.3.15):
+  extract-pg-schema@5.8.1(@electric-sql/pglite@0.3.16):
     dependencies:
       knex: 3.1.0(pg@8.17.2)
-      knex-pglite: 0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.20.0))
+      knex-pglite: 0.12.1(@electric-sql/pglite@0.3.16)(knex@3.1.0(pg@8.17.2))
       pg: 8.17.2
       pg-query-emscripten: 5.1.0
       ramda: 0.31.3
@@ -4602,12 +4372,12 @@ snapshots:
     dependencies:
       '@kristiandupont/recase': 1.4.1
 
-  kanel@3.16.1(@electric-sql/pglite@0.3.15):
+  kanel@3.16.1(@electric-sql/pglite@0.3.16):
     dependencies:
       '@kristiandupont/recase': 1.4.1
       chalk: 4.1.2
       cli-progress: 3.12.0
-      extract-pg-schema: 5.8.1(@electric-sql/pglite@0.3.15)
+      extract-pg-schema: 5.8.1(@electric-sql/pglite@0.3.16)
       optionator: 0.9.4
       pg: 8.20.0
       ramda: 0.32.0
@@ -4633,9 +4403,9 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knex-pglite@0.12.1(@electric-sql/pglite@0.3.15)(knex@3.1.0(pg@8.20.0)):
+  knex-pglite@0.12.1(@electric-sql/pglite@0.3.16)(knex@3.1.0(pg@8.17.2)):
     dependencies:
-      '@electric-sql/pglite': 0.3.15
+      '@electric-sql/pglite': 0.3.16
       knex: 3.1.0(pg@8.17.2)
 
   knex@3.1.0(pg@8.17.2):
@@ -5225,29 +4995,29 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-awesome-color-picker@4.1.1(svelte@5.53.12):
+  svelte-awesome-color-picker@4.1.1(svelte@5.53.11):
     dependencies:
       colord: 2.9.3
-      svelte: 5.53.12
-      svelte-awesome-slider: 2.0.0(svelte@5.53.12)
+      svelte: 5.53.11
+      svelte-awesome-slider: 2.0.0(svelte@5.53.11)
 
-  svelte-awesome-slider@2.0.0(svelte@5.53.12):
+  svelte-awesome-slider@2.0.0(svelte@5.53.11):
     dependencies:
-      svelte: 5.53.12
+      svelte: 5.53.11
 
-  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3):
+  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.53.11)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.53.12
+      svelte: 5.53.11
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.6.0(svelte@5.53.12):
+  svelte-eslint-parser@1.6.0(svelte@5.53.11):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -5257,9 +5027,9 @@ snapshots:
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
     optionalDependencies:
-      svelte: 5.53.12
+      svelte: 5.53.11
 
-  svelte@5.53.12:
+  svelte@5.53.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5293,9 +5063,9 @@ snapshots:
 
   tildify@2.0.0: {}
 
-  tinybase@7.3.2(@electric-sql/pglite@0.3.15)(ws@8.19.0)(zod@4.3.6):
+  tinybase@7.3.2(@electric-sql/pglite@0.3.16)(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
-      '@electric-sql/pglite': 0.3.15
+      '@electric-sql/pglite': 0.3.16
       ws: 8.19.0
       zod: 4.3.6
 
@@ -5357,7 +5127,7 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2):
+  vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -5367,19 +5137,18 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
-      esbuild: 0.27.3
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.2
 
-  vitefu@1.1.2(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)):
+  vitefu@1.1.2(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -5396,7 +5165,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/src/lib/components/LabelPage/LabelPage.svelte
+++ b/src/lib/components/LabelPage/LabelPage.svelte
@@ -7,22 +7,20 @@ import type { LabelId } from '#lib/ids.js'
 
 import { goto } from '$app/navigation'
 
-import { getDailyDurationList } from '#lib/core/select/get-daily-duration-list.js'
 import { getLabelCount } from '#lib/core/select/get-label-count.js'
 import { getLabelLastStartedAt } from '#lib/core/select/get-label-last-started-at.js'
 import { getStartYear } from '#lib/core/select/get-start-year.js'
 import { getTimeZone } from '#lib/core/select/get-time-zone.js'
 
-import * as calDateFns from '#lib/utils/calendar-date.js'
 import { clockMin } from '#lib/utils/clock.js'
-import { daysToMs, subDays } from '#lib/utils/days.js'
-import { formatDuration } from '#lib/utils/format-duration.js'
+import { subDays } from '#lib/utils/days.js'
 import { watch } from '#lib/utils/watch.svelte.js'
 
 import SecondaryButton from '#lib/components/Button/SecondaryButton.svelte'
 import Emoji from '#lib/components/Emoji/Emoji.svelte'
 
 import LabelHeatGrid from './LabelHeatGrid.svelte'
+import LabelWeekChart from './LabelWeekChart.svelte'
 
 type Props = {
   store: Store
@@ -31,12 +29,7 @@ type Props = {
 
 const { store, labelId }: Props = $props()
 
-const RANGE_DAYS = 30
-
 const { _: now } = $derived(watch(clockMin))
-
-const rangeStart = $derived(subDays(now, RANGE_DAYS))
-const rangeEnd = $derived(now)
 
 const { _: label } = $derived(watch(store.label.get(labelId)))
 const { _: timeZone } = $derived(watch(getTimeZone(store, now)))
@@ -67,27 +60,6 @@ const { _: pointCount } = $derived(
       )
     : watch.undefined,
 )
-
-const { _: dailyDurationList } = $derived(
-  label
-    ? watch(
-        getDailyDurationList(
-          store,
-          label.streamId,
-          { startedAt: { gte: rangeStart, lte: rangeEnd }, labelId },
-          now,
-        ),
-      )
-    : watch.lit([]),
-)
-
-const totalDurationMs = $derived(
-  dailyDurationList.reduce((sum, entry) => {
-    return sum + entry.durationMs
-  }, 0),
-)
-
-const totalPercentage = $derived(totalDurationMs / daysToMs(RANGE_DAYS))
 
 const handleDelete = async () => {
   if (
@@ -122,20 +94,15 @@ const handleDelete = async () => {
 
   <p>{pointCount} events in the last year</p>
   {#if labelLastStartedAt}
-    <p>Last used {dateFns.format(labelLastStartedAt, 'do MMMM yyyy, p', { in: tz(timeZone) })}</p>
+    <p>Last logged on {dateFns.format(labelLastStartedAt, 'do MMMM yyyy, p', { in: tz(timeZone) })}</p>
   {:else}
     <p>Never used</p>
   {/if}
 
-  <p>Total duration over last {RANGE_DAYS} days: {formatDuration(totalDurationMs)} ({Math.round(totalPercentage*100)}%)</p>
+  <LabelWeekChart {store} {labelId} />
 
   {#each yearList as year (year)}
     <LabelHeatGrid {store} {labelId} {year} />
-  {/each}
-
-  {#each dailyDurationList.toReversed() as entry (entry.date)}
-    <h4>{calDateFns.format(entry.date, 'do MMM yyyy')}</h4>
-    <p>{formatDuration(entry.durationMs)}</p>
   {/each}
 {/if}
 

--- a/src/lib/components/LabelPage/LabelWeekChart.svelte
+++ b/src/lib/components/LabelPage/LabelWeekChart.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+import { tz } from '@date-fns/tz'
+
+import type { Store } from '#lib/core/replicache/store.js'
+import type { LabelId } from '#lib/ids.js'
+import type { CalendarDate } from '#lib/utils/calendar-date.js'
+
+import { getDailyDurationList } from '#lib/core/select/get-daily-duration-list.js'
+import { getTimeZone } from '#lib/core/select/get-time-zone.js'
+
+import * as calDateFns from '#lib/utils/calendar-date.js'
+import { clockMin } from '#lib/utils/clock.js'
+import { watch } from '#lib/utils/watch.svelte.js'
+
+type Props = {
+  store: Store
+  labelId: LabelId
+}
+
+const { store, labelId }: Props = $props()
+
+const RANGE_WEEKS = 6
+const WEEKDAY = 'SMTWTFS'
+
+const { _: now } = $derived(watch(clockMin))
+const { _: timeZone } = $derived(watch(getTimeZone(store, now)))
+
+const today = $derived(calDateFns.fromInstant(now, tz(timeZone)))
+const dateEnd = $derived(calDateFns.endOfWeek(today)) // sunday
+const dateStart = $derived(
+  calDateFns.addDays(calDateFns.subWeeks(dateEnd, RANGE_WEEKS), 1),
+) // monday
+const dateList = $derived(
+  calDateFns.eachDayOfInterval({ start: dateStart, end: dateEnd }),
+)
+const weekList = Array.from({ length: RANGE_WEEKS }).map((_, i) => {
+  return dateList.slice(i * 7, (i + 1) * 7)
+})
+
+const { _: label } = $derived(watch(store.label.get(labelId)))
+
+const { _: dailyDurationList } = $derived(
+  label
+    ? watch(
+        getDailyDurationList(
+          store,
+          label.streamId,
+          {
+            startedAt: {
+              gte: calDateFns.toEarliestInstant(dateStart),
+              lte: calDateFns.toLatestInstant(dateEnd),
+            },
+            labelId,
+          },
+          now,
+        ),
+      )
+    : watch.lit([]),
+)
+
+const dailyDurationRecord = $derived.by(() => {
+  const record: Record<CalendarDate, number> = {}
+  for (const entry of dailyDurationList) {
+    record[entry.date] = entry.durationMs
+  }
+  return record
+})
+</script>
+
+<div class="LabelWeekChart" style:--cols={RANGE_WEEKS * 7} style:--color={label?.color ?? '#000'}>
+  <div class="chart">
+    {#each weekList as week, index (index)}
+      {#each week as date (date)}
+        {@const durationMs = dailyDurationRecord[date] ?? 0}
+        {@const isWeekend = calDateFns.isWeekend(date)}
+        <div class="day" class:isWeekend>
+          <div class="bar" style:--height={Math.round((durationMs / 1000 / 60) / 1440 * 100) + '%'}></div>
+          <div class="label">{WEEKDAY[calDateFns.dayOfWeek(date)]}</div>
+        </div>
+      {/each}
+    {/each}
+  </div>
+</div>
+
+<style>
+  .LabelWeekChart{
+    container-type: inline-size;
+  }
+
+  .chart {
+    --gap: var(--size-px);
+    --col-width: calc((100cqw - ((var(--cols) - 1) * var(--gap))) / var(--cols));
+
+    display: grid;
+    grid-template-columns: repeat(var(--cols), var(--col-width));
+    grid-template-rows: 200px 10px;
+    grid-auto-flow: column;
+    column-gap: var(--gap);
+    row-gap: var(--size-1);
+  }
+
+  .day {
+    display: contents;
+
+    .bar {
+      background: linear-gradient(
+        to bottom,
+        transparent calc(100% - var(--height)),
+        var(--color) calc(100% - var(--height))
+      );
+    }
+
+    .label {
+      text-align: center;
+      font-size: var(--scale-000);
+      color: var(--theme-text-muted);
+    }
+    &.isWeekend .label {
+      color: var(--color-grey-400);
+    }
+  }
+</style>

--- a/src/lib/core/select/get-daily-duration-list.ts
+++ b/src/lib/core/select/get-daily-duration-list.ts
@@ -10,7 +10,7 @@ import { createSelector } from '#lib/utils/selector.js'
 import { getFilteredLineList } from './get-filtered-line-list.js'
 import { getTimeZone } from './get-time-zone.js'
 
-type DailyEntry = {
+type DailyDuration = {
   date: CalendarDate
   durationMs: number
 }
@@ -42,7 +42,7 @@ const getDailyDurationList = createSelector(
     return computed('getDailyDurationList', () => {
       const lineList = $lineList.value
 
-      const entryRecord: Record<CalendarDate, DailyEntry> = {}
+      const entryRecord: Record<CalendarDate, DailyDuration> = {}
 
       for (const line of lineList) {
         const { startedAt, stoppedAt } = line

--- a/src/lib/utils/calendar-date.test.ts
+++ b/src/lib/utils/calendar-date.test.ts
@@ -6,6 +6,7 @@ import {
   addDays,
   dayOfWeek,
   eachDayOfInterval,
+  endOfWeek,
   format,
   formatISO,
   fromInstant,
@@ -17,6 +18,7 @@ import {
   getYear,
   isWeekend,
   subDays,
+  subWeeks,
   toEarliestInstant,
   toInstant,
   toLatestInstant,
@@ -222,40 +224,46 @@ describe('subDays', () => {
   })
 })
 
+describe('subWeeks', () => {
+  test('should subtract 1 week', () => {
+    const date = fromUTC(2026, 11, 31)
+    expect(subWeeks(date, 1)).toBe(fromUTC(2026, 11, 24))
+  })
+})
+
 describe('dayOfWeek', () => {
-  test('should return 0 for Sunday', () => {
-    const date = fromUTC(2026, 2, 1)
-    expect(dayOfWeek(date)).toBe(0)
+  test('should work in 2026', () => {
+    const sunday = fromUTC(2026, 2, 1)
+    expect(dayOfWeek(sunday)).toBe(0)
+
+    const monday = fromUTC(2026, 2, 2)
+    expect(dayOfWeek(monday)).toBe(1)
+
+    const tuesday = fromUTC(2026, 2, 3)
+    expect(dayOfWeek(tuesday)).toBe(2)
+
+    const wednesday = fromUTC(2026, 2, 4)
+    expect(dayOfWeek(wednesday)).toBe(3)
+
+    const thursday = fromUTC(2026, 2, 5)
+    expect(dayOfWeek(thursday)).toBe(4)
+
+    const friday = fromUTC(2026, 2, 6)
+    expect(dayOfWeek(friday)).toBe(5)
+
+    const saturday = fromUTC(2026, 2, 7)
+    expect(dayOfWeek(saturday)).toBe(6)
   })
 
-  test('should return 1 for Monday', () => {
-    const date = fromUTC(2026, 2, 2)
-    expect(dayOfWeek(date)).toBe(1)
-  })
+  test('should work in 2025', () => {
+    const jan = fromUTC(2025, 0, 5)
+    expect(dayOfWeek(jan)).toBe(0)
 
-  test('should return 2 for Tuesday', () => {
-    const date = fromUTC(2026, 2, 3)
-    expect(dayOfWeek(date)).toBe(2)
-  })
+    const feb = fromUTC(2025, 1, 2)
+    expect(dayOfWeek(feb)).toBe(0)
 
-  test('should return 3 for Wednesday', () => {
-    const date = fromUTC(2026, 2, 4)
-    expect(dayOfWeek(date)).toBe(3)
-  })
-
-  test('should return 4 for Thursday', () => {
-    const date = fromUTC(2026, 2, 5)
-    expect(dayOfWeek(date)).toBe(4)
-  })
-
-  test('should return 5 for Friday', () => {
-    const date = fromUTC(2026, 2, 6)
-    expect(dayOfWeek(date)).toBe(5)
-  })
-
-  test('should return 6 for Saturday', () => {
-    const date = fromUTC(2026, 2, 7)
-    expect(dayOfWeek(date)).toBe(6)
+    const mar = fromUTC(2025, 2, 2)
+    expect(dayOfWeek(mar)).toBe(0)
   })
 })
 
@@ -283,6 +291,26 @@ describe('isWeekend', () => {
 
     const friday = fromUTC(2026, 2, 6)
     expect(isWeekend(friday)).toBe(false)
+  })
+})
+
+describe('endOfWeek', () => {
+  test('should work in 2026', () => {
+    const monday = fromUTC(2026, 2, 2)
+    const tuesday = fromUTC(2026, 2, 3)
+    const wednesday = fromUTC(2026, 2, 4)
+    const thursday = fromUTC(2026, 2, 5)
+    const friday = fromUTC(2026, 2, 6)
+    const saturday = fromUTC(2026, 2, 7)
+    const sunday = fromUTC(2026, 2, 8)
+
+    expect(endOfWeek(sunday)).toBe(sunday)
+    expect(endOfWeek(monday)).toBe(sunday)
+    expect(endOfWeek(tuesday)).toBe(sunday)
+    expect(endOfWeek(wednesday)).toBe(sunday)
+    expect(endOfWeek(thursday)).toBe(sunday)
+    expect(endOfWeek(friday)).toBe(sunday)
+    expect(endOfWeek(saturday)).toBe(sunday)
   })
 })
 

--- a/src/lib/utils/calendar-date.ts
+++ b/src/lib/utils/calendar-date.ts
@@ -92,6 +92,10 @@ const addDays = (date: CalendarDate, days: number): CalendarDate => {
   return (date + days) as CalendarDate
 }
 
+const subWeeks = (date: CalendarDate, weeks: number): CalendarDate => {
+  return (date - weeks * 7) as CalendarDate
+}
+
 const dayOfWeek = (date: CalendarDate): number => {
   return (date + 4) % 7
 }
@@ -101,12 +105,23 @@ const isWeekend = (date: CalendarDate): boolean => {
   return day === 0 || day === 6
 }
 
+// if date is sunday, returns current date
+// else returns the next sunday after the current date
+const endOfWeek = (date: CalendarDate): CalendarDate => {
+  const value = dayOfWeek(date)
+  if (value === 0) {
+    return date
+  }
+  return (date + (7 - value)) as CalendarDate
+}
+
 export type { CalendarDate }
 
 export {
   addDays,
   dayOfWeek,
   eachDayOfInterval,
+  endOfWeek,
   format,
   formatISO,
   fromInstant,
@@ -119,6 +134,7 @@ export {
   isWeekend,
   MS_PER_DAY,
   subDays,
+  subWeeks,
   toEarliestInstant,
   toInstant,
   toLatestInstant,

--- a/src/lib/utils/days.ts
+++ b/src/lib/utils/days.ts
@@ -1,11 +1,7 @@
 const DAYS_MS = 24 * 60 * 60 * 1000
 
-const daysToMs = (days: number): number => {
-  return days * DAYS_MS
-}
-
 const subDays = (instant: number, days: number): number => {
   return instant - days * DAYS_MS
 }
 
-export { daysToMs, subDays }
+export { subDays }

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -126,6 +126,11 @@ const handleAssignLabelParent = async () => {
       <pre><code>aeon.**************************.*******************************************</code></pre>
       <button onclick={async () => { apiToken = await setApiToken() }}>Reset API Token</button>
     {/if}
+    <details>
+      <summary><strong>API Docs</strong></summary>
+      <strong>Get Status</strong>
+      <pre><code>curl https://aeon.party/api/v1/status -H "Authorization: Bearer API_TOKEN"</code></pre>
+    </details>
   </section>
 
   <section>


### PR DESCRIPTION
## Summary
Add a weekly bar-chart view for labels, update calendar helpers and tests, and refresh dependency lockfile/package manager metadata.

## Changes
- UI
  - Add new LabelWeekChart component and embed it in LabelPage to show a 6-week weekly bar chart per label.
  - Remove the 30-day total/daily list output from LabelPage and replace with the week chart. Minor copy change: "Last used" -> "Last logged on".
- Core/selectors
  - get-daily-duration-list: rename internal type (DailyEntry -> DailyDuration) and keep behavior the same.
- Utils & tests
  - Add calendar helpers: endOfWeek and subWeeks to calendar-date utilities and export them.
  - Update calendar-date tests to cover endOfWeek and to reorganize dayOfWeek tests.
- Settings & docs
  - Add a small "API Docs" details block to the Settings page (curl example for GET /api/v1/status).
- Dependencies / lockfile
  - Bump packageManager to pnpm@10.32.1 and update pnpm-lock.yaml (notable package revisions: @electric-sql/pglite -> 0.3.16, svelte pinned to 5.53.11 in the lockfile). Various platform/libc metadata and optional dependency references were also refreshed.

## Notes / Impact
- Developer action: run a fresh install (pnpm install) after pulling — the lockfile and packageManager field changed.
- Possible build impact: svelte version in the lockfile changed (5.53.12 -> 5.53.11) and @electric-sql/pglite was bumped; verify the app builds and tests locally.
- No runtime config or migrations required; UI change replaces the previous 30-day totals display with the new weekly chart for labels.